### PR TITLE
Replace EMA with LOESS smoothing and add dynamic bandwidth

### DIFF
--- a/.github/workflows/treemapper.yml
+++ b/.github/workflows/treemapper.yml
@@ -41,3 +41,5 @@ jobs:
             | Size | ${{ steps.context.outputs.size }} |
 
             [Download context](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact.outputs.artifact-id }})
+
+            Use this context for AI code review with ChatGPT, Claude, or other LLMs.

--- a/.github/workflows/treemapper.yml
+++ b/.github/workflows/treemapper.yml
@@ -32,13 +32,12 @@ jobs:
         with:
           header: treemapper
           message: |
-            ## 📊 Diff Context Ready
+            ## Diff Context
 
             | Metric | Value |
             |--------|-------|
             | Fragments | ${{ steps.context.outputs.fragment-count }} |
             | Tokens | ~${{ steps.context.outputs.token-count }} |
+            | Size | ${{ steps.context.outputs.size }} |
 
-            📥 [Download context](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact.outputs.artifact-id }})
-
-            Use this context for AI code review with ChatGPT, Claude, or other LLMs.
+            [Download context](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact.outputs.artifact-id }})

--- a/.github/workflows/treemapper.yml
+++ b/.github/workflows/treemapper.yml
@@ -1,0 +1,44 @@
+name: Diff Context
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  extract-context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract diff context
+        id: context
+        uses: nikolay-e/treemapper-action@v1
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        id: artifact
+        with:
+          name: diff-context
+          path: ${{ steps.context.outputs.context-file }}
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: treemapper
+          message: |
+            ## 📊 Diff Context Ready
+
+            | Metric | Value |
+            |--------|-------|
+            | Fragments | ${{ steps.context.outputs.fragment-count }} |
+            | Tokens | ~${{ steps.context.outputs.token-count }} |
+
+            📥 [Download context](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact.outputs.artifact-id }})
+
+            Use this context for AI code review with ChatGPT, Claude, or other LLMs.

--- a/frontend/src/components/charts/CaloriesChart.tsx
+++ b/frontend/src/components/charts/CaloriesChart.tsx
@@ -13,6 +13,8 @@ interface CaloriesChartProps {
   whoopData?: WhoopCycleData[];
   energyData?: EnergyData[];
   showTrends?: boolean;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 export const CaloriesChart = memo(
@@ -21,6 +23,8 @@ export const CaloriesChart = memo(
     whoopData = [],
     energyData = [],
     showTrends = false,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
   }: CaloriesChartProps) => {
     const config = MULTI_PROVIDER_CONFIGS.calories;
 
@@ -70,6 +74,8 @@ export const CaloriesChart = memo(
         yDomain={["dataMin - 100", "dataMax + 100"]}
         valueFormatter={(v) => v.toLocaleString()}
         showTrends={showTrends}
+        bandwidthShort={bandwidthShort}
+        bandwidthLong={bandwidthLong}
       />
     );
   },

--- a/frontend/src/components/charts/HRVChart.tsx
+++ b/frontend/src/components/charts/HRVChart.tsx
@@ -8,10 +8,18 @@ interface HRVChartProps {
   garminData: HRVData[];
   whoopData?: WhoopRecoveryData[];
   showTrends?: boolean;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 export const HRVChart = memo(
-  ({ garminData, whoopData = [], showTrends = false }: HRVChartProps) => {
+  ({
+    garminData,
+    whoopData = [],
+    showTrends = false,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
+  }: HRVChartProps) => {
     const config = MULTI_PROVIDER_CONFIGS.hrv;
 
     const mergedData = mergeProviderData(
@@ -30,6 +38,8 @@ export const HRVChart = memo(
         whoopLabel="Whoop HRV"
         unit="ms"
         showTrends={showTrends}
+        bandwidthShort={bandwidthShort}
+        bandwidthLong={bandwidthLong}
       />
     );
   },

--- a/frontend/src/components/charts/HeartRateChart.tsx
+++ b/frontend/src/components/charts/HeartRateChart.tsx
@@ -8,10 +8,18 @@ interface HeartRateChartProps {
   garminData: HeartRateData[];
   whoopData?: WhoopRecoveryData[];
   showTrends?: boolean;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 export const HeartRateChart = memo(
-  ({ garminData, whoopData = [], showTrends = false }: HeartRateChartProps) => {
+  ({
+    garminData,
+    whoopData = [],
+    showTrends = false,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
+  }: HeartRateChartProps) => {
     const config = MULTI_PROVIDER_CONFIGS.restingHr;
 
     const mergedData = mergeProviderData(
@@ -31,6 +39,8 @@ export const HeartRateChart = memo(
         unit="bpm"
         yDomain={["dataMin - 5", "dataMax + 5"]}
         showTrends={showTrends}
+        bandwidthShort={bandwidthShort}
+        bandwidthLong={bandwidthLong}
       />
     );
   },

--- a/frontend/src/components/charts/MultiProviderLineChart.tsx
+++ b/frontend/src/components/charts/MultiProviderLineChart.tsx
@@ -15,7 +15,7 @@ import { EmptyChartMessage } from "./shared";
 import { chartTooltipStyle } from "./chart-config";
 import { renderTrendLines } from "./TrendLines";
 import type { MultiProviderDataPoint } from "../../lib/chart-utils";
-import { calculateEMA } from "../../lib/statistics";
+import { loessSmooth } from "../../lib/statistics";
 
 interface MultiProviderLineChartProps {
   data: MultiProviderDataPoint[];
@@ -32,6 +32,8 @@ interface MultiProviderLineChartProps {
   valueFormatter?: (value: number) => string;
   baselineValue?: number | null;
   showTrends?: boolean;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 export const MultiProviderLineChart = memo(
@@ -47,6 +49,8 @@ export const MultiProviderLineChart = memo(
     valueFormatter = (v) => v.toFixed(0),
     baselineValue,
     showTrends = false,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
   }: MultiProviderLineChartProps) => {
     const hasData = data.some(
       (d) => d.garminValue !== null || d.whoopValue !== null,
@@ -63,17 +67,15 @@ export const MultiProviderLineChart = memo(
             : (d.garminValue ?? d.whoopValue),
       }));
 
-      const ema7 = calculateEMA(withAvg, 7, "avgValue");
-      const ema21 = calculateEMA(withAvg, 21, "avgValue");
-      const ema60 = calculateEMA(withAvg, 60, "avgValue");
+      const loessShort = loessSmooth(withAvg, "avgValue", bandwidthShort);
+      const loessLong = loessSmooth(withAvg, "avgValue", bandwidthLong);
 
       return withAvg.map((d, i) => ({
         ...d,
-        trend7: ema7[i]?.ema ?? null,
-        trend21: ema21[i]?.ema ?? null,
-        trend60: ema60[i]?.ema ?? null,
+        trendShort: loessShort[i]?.loess ?? null,
+        trendLong: loessLong[i]?.loess ?? null,
       }));
-    }, [data, showTrends]);
+    }, [data, showTrends, bandwidthShort, bandwidthLong]);
 
     if (!hasData) {
       return <EmptyChartMessage message={emptyMessage} />;
@@ -102,21 +104,17 @@ export const MultiProviderLineChart = memo(
               if (name === "whoopValue") {
                 return [`${valueFormatter(v)} ${unit}`, whoopLabel];
               }
-              if (name === "trend7") {
-                return [`${valueFormatter(v)} ${unit}`, "7d avg"];
+              if (name === "trendShort") {
+                return [`${valueFormatter(v)} ${unit}`, "Short trend"];
               }
-              if (name === "trend21") {
-                return [`${valueFormatter(v)} ${unit}`, "21d avg"];
-              }
-              if (name === "trend60") {
-                return [`${valueFormatter(v)} ${unit}`, "60d avg"];
+              if (name === "trendLong") {
+                return [`${valueFormatter(v)} ${unit}`, "Long trend"];
               }
               return [v, name];
             }}
             contentStyle={chartTooltipStyle}
           />
 
-          {/* Data points first (rendered below) */}
           <Line
             type="linear"
             dataKey="garminValue"
@@ -138,8 +136,7 @@ export const MultiProviderLineChart = memo(
             isAnimationActive={false}
           />
 
-          {/* Trend lines on top */}
-          {renderTrendLines(showTrends, "weight")}
+          {renderTrendLines(showTrends)}
 
           {baselineValue !== null && baselineValue !== undefined && (
             <ReferenceLine
@@ -163,14 +160,11 @@ export const MultiProviderLineChart = memo(
               if (value === "whoopValue") {
                 return whoopLabel;
               }
-              if (value === "trend7") {
-                return "7d avg";
+              if (value === "trendShort") {
+                return "Short trend";
               }
-              if (value === "trend21") {
-                return "21d avg";
-              }
-              if (value === "trend60") {
-                return "60d avg";
+              if (value === "trendLong") {
+                return "Long trend";
               }
               return value;
             }}

--- a/frontend/src/components/charts/SleepChart.tsx
+++ b/frontend/src/components/charts/SleepChart.tsx
@@ -16,13 +16,15 @@ import type { SleepData, WhoopSleepData } from "../../types/api";
 import { EmptyChartMessage } from "./shared";
 import { chartTooltipStyle, MULTI_PROVIDER_CONFIGS } from "./chart-config";
 import { sortByDateAsc } from "../../lib/chart-utils";
-import { calculateEMA } from "../../lib/statistics";
+import { loessSmooth } from "../../lib/statistics";
 
 interface SleepChartProps {
   garminData: SleepData[];
   whoopData?: WhoopSleepData[];
   showBreakdown?: boolean;
   showTrends?: boolean;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 const SLEEP_STAGE_COLORS = {
@@ -38,6 +40,8 @@ export const SleepChart = memo(
     whoopData = [],
     showBreakdown = false,
     showTrends = false,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
   }: SleepChartProps) => {
     const config = MULTI_PROVIDER_CONFIGS.sleep;
 
@@ -95,15 +99,15 @@ export const SleepChart = memo(
             : (d.garminTotal ?? d.whoopTotal),
       }));
 
-      const ema7 = calculateEMA(withAvg, 7, "avgValue");
-      const ema21 = calculateEMA(withAvg, 21, "avgValue");
+      const loessShort = loessSmooth(withAvg, "avgValue", bandwidthShort);
+      const loessLong = loessSmooth(withAvg, "avgValue", bandwidthLong);
 
       return withAvg.map((d, i) => ({
         ...d,
-        trend7: ema7[i]?.ema ?? null,
-        trend21: ema21[i]?.ema ?? null,
+        trendShort: loessShort[i]?.loess ?? null,
+        trendLong: loessLong[i]?.loess ?? null,
       }));
-    }, [chartData, showTrends]);
+    }, [chartData, showTrends, bandwidthShort, bandwidthLong]);
 
     if (!hasData) {
       return <EmptyChartMessage message="No sleep data available" />;
@@ -193,11 +197,11 @@ export const SleepChart = memo(
               if (name === "whoopTotal") {
                 return [formatHours(Number(value)), "Whoop"];
               }
-              if (name === "trend7") {
-                return [formatHours(Number(value)), "7-day avg"];
+              if (name === "trendShort") {
+                return [formatHours(Number(value)), "Short trend"];
               }
-              if (name === "trend21") {
-                return [formatHours(Number(value)), "21-day avg"];
+              if (name === "trendLong") {
+                return [formatHours(Number(value)), "Long trend"];
               }
               return [formatHours(Number(value)), name];
             }}
@@ -207,8 +211,8 @@ export const SleepChart = memo(
             formatter={(value) => {
               if (value === "garminTotal") return "Garmin";
               if (value === "whoopTotal") return "Whoop";
-              if (value === "trend7") return "7-day avg";
-              if (value === "trend21") return "21-day avg";
+              if (value === "trendShort") return "Short trend";
+              if (value === "trendLong") return "Long trend";
               return value;
             }}
           />
@@ -226,26 +230,25 @@ export const SleepChart = memo(
           />
           {showTrends && (
             <Line
-              type="monotone"
-              dataKey="trend7"
+              type="natural"
+              dataKey="trendShort"
               stroke="hsl(var(--foreground) / 0.7)"
-              strokeWidth={2.5}
-              strokeDasharray="6 4"
+              strokeWidth={1.5}
+              strokeDasharray="4 4"
               dot={false}
-              name="trend7"
-              connectNulls
+              name="trendShort"
+              connectNulls={false}
             />
           )}
           {showTrends && (
             <Line
-              type="monotone"
-              dataKey="trend21"
+              type="natural"
+              dataKey="trendLong"
               stroke="hsl(var(--foreground) / 0.5)"
-              strokeWidth={2}
-              strokeDasharray="10 5"
+              strokeWidth={2.5}
               dot={false}
-              name="trend21"
-              connectNulls
+              name="trendLong"
+              connectNulls={false}
             />
           )}
         </ComposedChart>

--- a/frontend/src/components/charts/StepsChart.tsx
+++ b/frontend/src/components/charts/StepsChart.tsx
@@ -22,10 +22,17 @@ import { useTrendData } from "../../hooks/useTrendData";
 interface StepsChartProps {
   data: StepsData[];
   showTrends?: boolean;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 export const StepsChart = memo(
-  ({ data, showTrends = false }: StepsChartProps) => {
+  ({
+    data,
+    showTrends = false,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
+  }: StepsChartProps) => {
     const config = TREND_CONFIGS.steps;
 
     const normalizedData = data.map((d) => ({
@@ -35,9 +42,9 @@ export const StepsChart = memo(
     }));
 
     const { chartData, hasData } = useTrendData(normalizedData, "total_steps", {
-      method: config.method,
-      shortTermWindow: 7,
-      longTermWindow: 21,
+      method: "loess",
+      bandwidthShort,
+      bandwidthLong,
       showBaseline: false,
     });
 
@@ -64,11 +71,11 @@ export const StepsChart = memo(
               const v = value as number | undefined;
               if (v === undefined) return ["-", name];
               if (name === "value") return [v.toLocaleString(), "Steps"];
-              if (name === "shortTermTrend") {
-                return [`${(v / 1000).toFixed(1)}k`, "7-day avg"];
+              if (name === "trendShort") {
+                return [`${(v / 1000).toFixed(1)}k`, "Short trend"];
               }
-              if (name === "longTermTrend") {
-                return [`${(v / 1000).toFixed(1)}k`, "21-day avg"];
+              if (name === "trendLong") {
+                return [`${(v / 1000).toFixed(1)}k`, "Long trend"];
               }
               return [v, name];
             }}
@@ -114,24 +121,24 @@ export const StepsChart = memo(
 
           {showTrends && (
             <Line
-              type="monotone"
-              dataKey="shortTermTrend"
-              stroke={config.trendColor}
-              strokeWidth={2}
-              strokeDasharray="5 5"
+              type="natural"
+              dataKey="trendShort"
+              stroke="hsl(var(--foreground) / 0.7)"
+              strokeWidth={1.5}
+              strokeDasharray="4 4"
               dot={false}
-              name="shortTermTrend"
+              name="trendShort"
             />
           )}
 
           {showTrends && (
             <Line
-              type="monotone"
-              dataKey="longTermTrend"
-              stroke={config.longTermTrendColor}
-              strokeWidth={3}
+              type="natural"
+              dataKey="trendLong"
+              stroke="hsl(var(--foreground) / 0.5)"
+              strokeWidth={2.5}
               dot={false}
-              name="longTermTrend"
+              name="trendLong"
             />
           )}
 

--- a/frontend/src/components/charts/StressChart.tsx
+++ b/frontend/src/components/charts/StressChart.tsx
@@ -19,10 +19,17 @@ import { useTrendData } from "../../hooks/useTrendData";
 interface StressChartProps {
   data: StressData[];
   showTrends?: boolean;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 export const StressChart = memo(
-  ({ data, showTrends = false }: StressChartProps) => {
+  ({
+    data,
+    showTrends = false,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
+  }: StressChartProps) => {
     const config = TREND_CONFIGS.stress;
 
     const normalizedData = data.map((d) => ({
@@ -32,10 +39,9 @@ export const StressChart = memo(
     }));
 
     const { chartData, hasData } = useTrendData(normalizedData, "avg_stress", {
-      method: config.method,
-      shortTermWindow: 7,
-      longTermWindow: 21,
-      longerTermWindow: 60,
+      method: "loess",
+      bandwidthShort,
+      bandwidthLong,
       showBaseline: false,
     });
 
@@ -59,9 +65,8 @@ export const StressChart = memo(
               const v = value as number | undefined;
               if (v === undefined) return ["-", name];
               if (name === "value") return [v.toFixed(0), "Avg Stress"];
-              if (name === "shortTermTrend") return [v.toFixed(0), "7d avg"];
-              if (name === "longTermTrend") return [v.toFixed(0), "21d avg"];
-              if (name === "longerTermTrend") return [v.toFixed(0), "60d avg"];
+              if (name === "trendShort") return [v.toFixed(0), "Short trend"];
+              if (name === "trendLong") return [v.toFixed(0), "Long trend"];
               return [v, name];
             }}
             contentStyle={chartTooltipStyle}
@@ -86,9 +91,8 @@ export const StressChart = memo(
             <Legend
               formatter={(value) => {
                 if (value === "value") return "Stress";
-                if (value === "shortTermTrend") return "7d avg";
-                if (value === "longTermTrend") return "21d avg";
-                if (value === "longerTermTrend") return "60d avg";
+                if (value === "trendShort") return "Short trend";
+                if (value === "trendLong") return "Long trend";
                 return value;
               }}
             />

--- a/frontend/src/components/charts/TrendLineChart.tsx
+++ b/frontend/src/components/charts/TrendLineChart.tsx
@@ -22,16 +22,12 @@ interface TrendLineChartProps {
   baseline: BaselineData | null;
   config: {
     color: string;
-    trendColor: string;
-    longTermTrendColor: string;
-    longerTermTrendColor: string;
   };
   emptyMessage: string;
   valueLabel: string;
   unit: string;
-  shortTermLabel: string;
-  longTermLabel: string;
-  longerTermLabel: string;
+  shortTermLabel?: string;
+  longTermLabel?: string;
   showTrends?: boolean;
   showBaseline?: boolean;
   height?: number | `${number}%`;
@@ -47,9 +43,8 @@ function TrendLineChartComponent({
   emptyMessage,
   valueLabel,
   unit,
-  shortTermLabel,
-  longTermLabel,
-  longerTermLabel,
+  shortTermLabel = "Short trend",
+  longTermLabel = "Long trend",
   showTrends = false,
   showBaseline = false,
   height = 250,
@@ -78,14 +73,11 @@ function TrendLineChartComponent({
             if (name === "value") {
               return [`${valueFormatter(v)} ${unit}`, valueLabel];
             }
-            if (name === "shortTermTrend") {
+            if (name === "trendShort") {
               return [`${valueFormatter(v)} ${unit}`, shortTermLabel];
             }
-            if (name === "longTermTrend") {
+            if (name === "trendLong") {
               return [`${valueFormatter(v)} ${unit}`, longTermLabel];
-            }
-            if (name === "longerTermTrend") {
-              return [`${valueFormatter(v)} ${unit}`, longerTermLabel];
             }
             return [String(v), name];
           }}
@@ -138,9 +130,8 @@ function TrendLineChartComponent({
           <Legend
             formatter={(value) => {
               if (value === "value") return valueLabel;
-              if (value === "shortTermTrend") return shortTermLabel;
-              if (value === "longTermTrend") return longTermLabel;
-              if (value === "longerTermTrend") return longerTermLabel;
+              if (value === "trendShort") return shortTermLabel;
+              if (value === "trendLong") return longTermLabel;
               return value;
             }}
           />

--- a/frontend/src/components/charts/TrendLines.tsx
+++ b/frontend/src/components/charts/TrendLines.tsx
@@ -4,35 +4,28 @@ interface TrendLineConfig {
   dataKey: string;
   strokeWidth: number;
   strokeDasharray?: string;
+  opacity: number;
 }
 
 const TREND_LINE_CONFIGS: TrendLineConfig[] = [
-  { dataKey: "shortTermTrend", strokeWidth: 1.5, strokeDasharray: "4 4" },
-  { dataKey: "longTermTrend", strokeWidth: 2, strokeDasharray: "8 4" },
-  { dataKey: "longerTermTrend", strokeWidth: 2.5 },
+  {
+    dataKey: "trendShort",
+    strokeWidth: 1.5,
+    strokeDasharray: "4 4",
+    opacity: 0.7,
+  },
+  { dataKey: "trendLong", strokeWidth: 2.5, opacity: 0.5 },
 ];
 
-const WEIGHT_TREND_CONFIGS: TrendLineConfig[] = [
-  { dataKey: "trend7", strokeWidth: 1.5, strokeDasharray: "4 4" },
-  { dataKey: "trend21", strokeWidth: 2, strokeDasharray: "8 4" },
-  { dataKey: "trend60", strokeWidth: 2.5 },
-];
-
-export function renderTrendLines(
-  show: boolean,
-  variant: "standard" | "weight" = "standard",
-): React.ReactNode[] | null {
+export function renderTrendLines(show: boolean): React.ReactNode[] | null {
   if (!show) return null;
 
-  const configs =
-    variant === "weight" ? WEIGHT_TREND_CONFIGS : TREND_LINE_CONFIGS;
-
-  return configs.map((config) => (
+  return TREND_LINE_CONFIGS.map((config) => (
     <Line
       key={config.dataKey}
       type="natural"
       dataKey={config.dataKey}
-      stroke="hsl(var(--foreground))"
+      stroke={`hsl(var(--foreground) / ${String(config.opacity)})`}
       strokeWidth={config.strokeWidth}
       strokeDasharray={config.strokeDasharray}
       dot={false}

--- a/frontend/src/components/charts/WeightChart.tsx
+++ b/frontend/src/components/charts/WeightChart.tsx
@@ -18,17 +18,25 @@ import { renderTrendLines } from "./TrendLines";
 import {
   calculateBiologicalWeightSmoothing,
   calculateBaseline,
-  calculateEMA,
+  loessSmooth,
 } from "../../lib/statistics";
 
 interface WeightChartProps {
   data: WeightData[];
   showTrends?: boolean;
   showBaseline?: boolean;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 export const WeightChart = memo(
-  ({ data, showTrends = false, showBaseline = false }: WeightChartProps) => {
+  ({
+    data,
+    showTrends = false,
+    showBaseline = false,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
+  }: WeightChartProps) => {
     const config = TREND_CONFIGS.weight;
 
     const { chartData, baseline, minWeight, maxWeight, padding, hasData } =
@@ -68,18 +76,20 @@ export const WeightChart = memo(
 
         const baselineData = calculateBaseline(normalizedData, 14, "weight_kg");
 
-        const dataForEMA = smoothedData as unknown as ({
+        const dataForLoess = smoothedData as unknown as ({
           date: string;
         } & Record<string, unknown>)[];
-        const ema7 = calculateEMA(dataForEMA, 7, "rawWeight");
-        const ema21 = calculateEMA(dataForEMA, 21, "rawWeight");
-        const ema60 = calculateEMA(dataForEMA, 60, "rawWeight");
+        const loessShort = loessSmooth(
+          dataForLoess,
+          "rawWeight",
+          bandwidthShort,
+        );
+        const loessLong = loessSmooth(dataForLoess, "rawWeight", bandwidthLong);
 
         const withTrends = smoothedData.map((d, i) => ({
           ...d,
-          trend7: ema7[i]?.ema ?? null,
-          trend21: ema21[i]?.ema ?? null,
-          trend60: ema60[i]?.ema ?? null,
+          trendShort: loessShort[i]?.loess ?? null,
+          trendLong: loessLong[i]?.loess ?? null,
         }));
 
         return {
@@ -90,7 +100,7 @@ export const WeightChart = memo(
           padding: pad,
           hasData: true,
         };
-      }, [data]);
+      }, [data, bandwidthShort, bandwidthLong]);
 
     if (!hasData) {
       return <EmptyChartMessage message="No weight data available" />;
@@ -116,9 +126,12 @@ export const WeightChart = memo(
               const v = value as number | null;
               if (v === null) return ["-", name];
               if (name === "rawWeight") return [`${v.toFixed(1)} kg`, "Weight"];
-              if (name === "trend7") return [`${v.toFixed(1)} kg`, "7d avg"];
-              if (name === "trend21") return [`${v.toFixed(1)} kg`, "21d avg"];
-              if (name === "trend60") return [`${v.toFixed(1)} kg`, "60d avg"];
+              if (name === "trendShort") {
+                return [`${v.toFixed(1)} kg`, "Short trend"];
+              }
+              if (name === "trendLong") {
+                return [`${v.toFixed(1)} kg`, "Long trend"];
+              }
               return [v, name];
             }}
             contentStyle={chartTooltipStyle}
@@ -151,7 +164,6 @@ export const WeightChart = memo(
             </>
           )}
 
-          {/* Data points first (rendered below) */}
           <Line
             type="linear"
             dataKey="rawWeight"
@@ -163,16 +175,14 @@ export const WeightChart = memo(
             isAnimationActive={false}
           />
 
-          {/* Trend lines on top */}
-          {renderTrendLines(showTrends, "weight")}
+          {renderTrendLines(showTrends)}
 
           {showTrends && (
             <Legend
               formatter={(value) => {
                 if (value === "rawWeight") return "Weight";
-                if (value === "trend7") return "7d avg";
-                if (value === "trend21") return "21d avg";
-                if (value === "trend60") return "60d avg";
+                if (value === "trendShort") return "Short trend";
+                if (value === "trendLong") return "Long trend";
                 return value;
               }}
             />

--- a/frontend/src/components/charts/WhoopRecoveryChart.tsx
+++ b/frontend/src/components/charts/WhoopRecoveryChart.tsx
@@ -8,6 +8,8 @@ interface WhoopRecoveryChartProps {
   data: WhoopRecoveryData[];
   showTrends?: boolean;
   showBaseline?: boolean;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 export const WhoopRecoveryChart = memo(
@@ -15,6 +17,8 @@ export const WhoopRecoveryChart = memo(
     data,
     showTrends = false,
     showBaseline = false,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
   }: WhoopRecoveryChartProps) => {
     const config = TREND_CONFIGS.whoopRecovery;
 
@@ -27,9 +31,9 @@ export const WhoopRecoveryChart = memo(
       normalizedData,
       "recovery_score",
       {
-        method: config.method,
-        shortTermWindow: 7,
-        longTermWindow: 21,
+        method: "loess",
+        bandwidthShort,
+        bandwidthLong,
         showBaseline,
         baselineWindow: config.baselineWindow,
       },
@@ -44,9 +48,8 @@ export const WhoopRecoveryChart = memo(
         emptyMessage="No Whoop recovery data available"
         valueLabel="Recovery"
         unit="%"
-        shortTermLabel="7-day avg"
-        longTermLabel="21-day avg"
-        longerTermLabel="90-day avg"
+        shortTermLabel="Short trend"
+        longTermLabel="Long trend"
         showTrends={showTrends}
         showBaseline={showBaseline}
       />

--- a/frontend/src/features/dashboard/DashboardOverview.tsx
+++ b/frontend/src/features/dashboard/DashboardOverview.tsx
@@ -34,7 +34,13 @@ import {
   Check,
   type LucideIcon,
 } from "lucide-react";
-import { buildDashboardCards, type MetricCardVM } from "../../lib/metrics";
+import {
+  buildDashboardCards,
+  TREND_MODES,
+  MODE_ORDER,
+  type MetricCardVM,
+  type ViewMode,
+} from "../../lib/metrics";
 import { toTimeMs } from "../../lib/health";
 import { getLatestSyncDate } from "../../lib/sync-utils";
 
@@ -73,18 +79,9 @@ function MetricCard({
   );
 }
 
-const TIME_RANGES = [
-  { label: "Today", days: 1, description: "Latest" },
-  { label: "Short", days: 84, description: "12 weeks" },
-  { label: "Mid", days: 252, description: "9 months" },
-  { label: "Long", days: 730, description: "2 years" },
-] as const;
-
-type TimeRangeLabel = (typeof TIME_RANGES)[number]["label"] | "Custom";
-
 export function DashboardOverview() {
   const today = new Date();
-  const [selectedRange, setSelectedRange] = useState<TimeRangeLabel>("Short");
+  const [selectedRange, setSelectedRange] = useState<ViewMode>("recent");
   const [customStartDate, setCustomStartDate] = useState(
     format(subDays(today, 90), "yyyy-MM-dd"),
   );
@@ -92,20 +89,26 @@ export function DashboardOverview() {
     format(today, "yyyy-MM-dd"),
   );
 
-  const isToday = selectedRange === "Today";
-  const rangeDays =
-    TIME_RANGES.find((r) => r.label === selectedRange)?.days ?? 84;
+  const isToday = selectedRange === "today";
+  const isCustom = selectedRange === "custom";
+  const modeConfig =
+    selectedRange !== "today" && selectedRange !== "custom"
+      ? TREND_MODES[selectedRange]
+      : null;
+  const rangeDays = modeConfig?.rangeDays ?? 42;
+  const bandwidthShort = modeConfig?.bandwidthShort ?? 0.17;
+  const bandwidthLong = modeConfig?.bandwidthLong ?? 0.33;
 
-  const startDate =
-    selectedRange === "Custom"
-      ? customStartDate
+  const startDate = isCustom
+    ? customStartDate
+    : isToday
+      ? format(today, "yyyy-MM-dd")
       : format(subDays(today, rangeDays), "yyyy-MM-dd");
-  const endDate =
-    selectedRange === "Custom"
-      ? customEndDate
-      : isToday
-        ? format(today, "yyyy-MM-dd")
-        : format(subDays(today, 1), "yyyy-MM-dd");
+  const endDate = isCustom
+    ? customEndDate
+    : isToday
+      ? format(today, "yyyy-MM-dd")
+      : format(subDays(today, 1), "yyyy-MM-dd");
 
   const selectedDays = Math.max(
     1,
@@ -126,10 +129,11 @@ export function DashboardOverview() {
   const handleCopyToClipboard = useCallback(async () => {
     if (metricCards.length === 0) return;
 
-    const rangeLabel =
-      selectedRange === "Custom"
-        ? `${startDate} — ${endDate}`
-        : `${selectedRange} (${String(selectedDays)} days)`;
+    const rangeLabel = isCustom
+      ? `${startDate} — ${endDate}`
+      : isToday
+        ? "Today"
+        : `${modeConfig?.label ?? selectedRange} (${String(selectedDays)} days)`;
 
     const lines = [
       `Health Dashboard — ${rangeLabel}`,
@@ -154,9 +158,10 @@ export function DashboardOverview() {
       toast.error("Failed to copy to clipboard");
     }
   }, [
-    data,
-    isLoading,
     metricCards,
+    isCustom,
+    isToday,
+    modeConfig,
     selectedRange,
     selectedDays,
     startDate,
@@ -187,32 +192,46 @@ export function DashboardOverview() {
           </div>
           <div className="flex items-center gap-1.5 p-1 bg-muted/50 rounded-lg flex-wrap">
             <Calendar className="h-4 w-4 text-muted-foreground ml-2" />
-            {TIME_RANGES.map((range) => (
-              <Button
-                key={range.label}
-                variant={selectedRange === range.label ? "default" : "ghost"}
-                size="sm"
-                onClick={() => {
-                  setSelectedRange(range.label);
-                }}
-                className="min-w-[70px] flex flex-col h-auto py-1.5"
-              >
-                <span className="font-medium">{range.label}</span>
-                <span className="text-[10px] opacity-70">
-                  {range.description}
-                </span>
-              </Button>
-            ))}
             <Button
-              variant={selectedRange === "Custom" ? "default" : "ghost"}
+              variant={selectedRange === "today" ? "default" : "ghost"}
               size="sm"
               onClick={() => {
-                setSelectedRange("Custom");
+                setSelectedRange("today");
               }}
-              className="min-w-[70px] flex flex-col h-auto py-1.5"
+              className="min-w-[60px] flex flex-col h-auto py-1.5"
+            >
+              <span className="font-medium">Today</span>
+              <span className="text-[10px] opacity-70">Latest</span>
+            </Button>
+            {MODE_ORDER.map((m) => {
+              const cfg = TREND_MODES[m];
+              return (
+                <Button
+                  key={m}
+                  variant={selectedRange === m ? "default" : "ghost"}
+                  size="sm"
+                  onClick={() => {
+                    setSelectedRange(m);
+                  }}
+                  className="min-w-[60px] flex flex-col h-auto py-1.5"
+                >
+                  <span className="font-medium">{cfg.label}</span>
+                  <span className="text-[10px] opacity-70">
+                    {cfg.description}
+                  </span>
+                </Button>
+              );
+            })}
+            <Button
+              variant={selectedRange === "custom" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => {
+                setSelectedRange("custom");
+              }}
+              className="min-w-[60px] flex flex-col h-auto py-1.5"
             >
               <span className="font-medium">Custom</span>
-              <span className="text-[10px] opacity-70">Date range</span>
+              <span className="text-[10px] opacity-70">Range</span>
             </Button>
             <Button
               variant="ghost"
@@ -228,7 +247,7 @@ export function DashboardOverview() {
               )}
             </Button>
           </div>
-          {selectedRange === "Custom" && (
+          {isCustom && (
             <div className="flex items-center gap-2 mt-2">
               <Input
                 type="date"
@@ -299,6 +318,8 @@ export function DashboardOverview() {
             garminData={data?.hrv ?? []}
             whoopData={data?.whoop_recovery ?? []}
             showTrends
+            bandwidthShort={bandwidthShort}
+            bandwidthLong={bandwidthLong}
           />
         </ChartCard>
 
@@ -312,6 +333,8 @@ export function DashboardOverview() {
             garminData={data?.sleep ?? []}
             whoopData={data?.whoop_sleep ?? []}
             showTrends
+            bandwidthShort={bandwidthShort}
+            bandwidthLong={bandwidthLong}
           />
         </ChartCard>
 
@@ -321,7 +344,12 @@ export function DashboardOverview() {
           iconColorClass="text-weight"
           iconBgClass="bg-weight-muted"
         >
-          <WeightChart data={data?.weight ?? []} showTrends />
+          <WeightChart
+            data={data?.weight ?? []}
+            showTrends
+            bandwidthShort={bandwidthShort}
+            bandwidthLong={bandwidthLong}
+          />
         </ChartCard>
 
         <ChartCard
@@ -334,6 +362,8 @@ export function DashboardOverview() {
             garminData={data?.heart_rate ?? []}
             whoopData={data?.whoop_recovery ?? []}
             showTrends
+            bandwidthShort={bandwidthShort}
+            bandwidthLong={bandwidthLong}
           />
         </ChartCard>
       </div>
@@ -345,7 +375,12 @@ export function DashboardOverview() {
           iconColorClass="text-steps"
           iconBgClass="bg-steps-muted"
         >
-          <StepsChart data={data?.steps ?? []} showTrends />
+          <StepsChart
+            data={data?.steps ?? []}
+            showTrends
+            bandwidthShort={bandwidthShort}
+            bandwidthLong={bandwidthLong}
+          />
         </ChartCard>
 
         <ChartCard
@@ -354,7 +389,12 @@ export function DashboardOverview() {
           iconColorClass="text-whoop"
           iconBgClass="bg-whoop-muted"
         >
-          <WhoopRecoveryChart data={data?.whoop_recovery ?? []} showTrends />
+          <WhoopRecoveryChart
+            data={data?.whoop_recovery ?? []}
+            showTrends
+            bandwidthShort={bandwidthShort}
+            bandwidthLong={bandwidthLong}
+          />
         </ChartCard>
 
         <ChartCard
@@ -363,7 +403,12 @@ export function DashboardOverview() {
           iconColorClass="text-stress"
           iconBgClass="bg-stress-muted"
         >
-          <StressChart data={data?.stress ?? []} showTrends />
+          <StressChart
+            data={data?.stress ?? []}
+            showTrends
+            bandwidthShort={bandwidthShort}
+            bandwidthLong={bandwidthLong}
+          />
         </ChartCard>
 
         <ChartCard
@@ -377,6 +422,8 @@ export function DashboardOverview() {
             whoopData={data?.whoop_cycle ?? []}
             energyData={data?.energy ?? []}
             showTrends
+            bandwidthShort={bandwidthShort}
+            bandwidthLong={bandwidthLong}
           />
         </ChartCard>
       </div>

--- a/frontend/src/features/dashboard/TrendsPage.tsx
+++ b/frontend/src/features/dashboard/TrendsPage.tsx
@@ -399,7 +399,7 @@ function formatTrendsForLLM(
 }
 
 export function TrendsPage() {
-  const [mode, setMode] = useState<TrendMode>("short");
+  const [mode, setMode] = useState<TrendMode>("recent");
   const [copied, setCopied] = useState(false);
   const modeConfig = TREND_MODES[mode];
   const {

--- a/frontend/src/hooks/useTrendData.ts
+++ b/frontend/src/hooks/useTrendData.ts
@@ -3,26 +3,27 @@ import {
   calculateEMA,
   calculateSMA,
   calculateBaseline,
+  loessSmooth,
 } from "../lib/statistics";
 import { sortByDateAsc } from "../lib/chart-utils";
 
-type TrendMethod = "ema" | "sma";
+type TrendMethod = "ema" | "sma" | "loess";
 
 interface TrendOptions {
   method?: TrendMethod;
   shortTermWindow?: number;
   longTermWindow?: number;
-  longerTermWindow?: number;
   showBaseline?: boolean;
   baselineWindow?: number;
+  bandwidthShort?: number;
+  bandwidthLong?: number;
 }
 
 export interface TrendDataPoint {
   date: string;
   value: number | null;
-  shortTermTrend: number | null;
-  longTermTrend: number | null;
-  longerTermTrend: number | null;
+  trendShort: number | null;
+  trendLong: number | null;
 }
 
 export type TrendChartData = TrendDataPoint;
@@ -44,12 +45,13 @@ export function useTrendData<T extends { date: string }>(
   options: TrendOptions = {},
 ): TrendResult<T> {
   const {
-    method = "ema",
+    method = "loess",
     shortTermWindow = 7,
     longTermWindow = 30,
-    longerTermWindow = 90,
     showBaseline = false,
     baselineWindow = 14,
+    bandwidthShort = 0.17,
+    bandwidthLong = 0.33,
   } = options;
 
   return useMemo(() => {
@@ -73,30 +75,32 @@ export function useTrendData<T extends { date: string }>(
 
     let withTrends: Array<
       (typeof normalized)[number] & {
-        shortTrend: number | null;
-        longTrend: number | null;
-        longerTrend: number | null;
+        trendShort: number | null;
+        trendLong: number | null;
       }
     >;
 
-    if (method === "ema") {
+    if (method === "loess") {
+      const shortTermResult = loessSmooth(normalized, "value", bandwidthShort);
+      const longTermResult = loessSmooth(normalized, "value", bandwidthLong);
+
+      withTrends = normalized.map((d, idx) => ({
+        ...d,
+        trendShort: shortTermResult[idx]?.loess ?? null,
+        trendLong: longTermResult[idx]?.loess ?? null,
+      }));
+    } else if (method === "ema") {
       const shortTermResult = calculateEMA(
         normalized,
         shortTermWindow,
         "value",
       );
       const longTermResult = calculateEMA(normalized, longTermWindow, "value");
-      const longerTermResult = calculateEMA(
-        normalized,
-        longerTermWindow,
-        "value",
-      );
 
       withTrends = normalized.map((d, idx) => ({
         ...d,
-        shortTrend: shortTermResult[idx]?.ema ?? null,
-        longTrend: longTermResult[idx]?.ema ?? null,
-        longerTrend: longerTermResult[idx]?.ema ?? null,
+        trendShort: shortTermResult[idx]?.ema ?? null,
+        trendLong: longTermResult[idx]?.ema ?? null,
       }));
     } else {
       const shortTermResult = calculateSMA(
@@ -105,26 +109,15 @@ export function useTrendData<T extends { date: string }>(
         "value",
       );
       const longTermResult = calculateSMA(normalized, longTermWindow, "value");
-      const longerTermResult = calculateSMA(
-        normalized,
-        longerTermWindow,
-        "value",
-      );
 
       withTrends = normalized.map((d, idx) => ({
         ...d,
-        shortTrend: shortTermResult[idx]?.sma ?? null,
-        longTrend: longTermResult[idx]?.sma ?? null,
-        longerTrend: longerTermResult[idx]?.sma ?? null,
+        trendShort: shortTermResult[idx]?.sma ?? null,
+        trendLong: longTermResult[idx]?.sma ?? null,
       }));
     }
 
-    const chartData = withTrends.map((d) => ({
-      ...d,
-      shortTermTrend: d.shortTrend,
-      longTermTrend: d.longTrend,
-      longerTermTrend: d.longerTrend,
-    })) as (T & TrendDataPoint)[];
+    const chartData = withTrends as (T & TrendDataPoint)[];
 
     const baseline = showBaseline
       ? calculateBaseline(normalized, baselineWindow, "value")
@@ -139,8 +132,9 @@ export function useTrendData<T extends { date: string }>(
     method,
     shortTermWindow,
     longTermWindow,
-    longerTermWindow,
     showBaseline,
     baselineWindow,
+    bandwidthShort,
+    bandwidthLong,
   ]);
 }

--- a/frontend/src/lib/metrics/index.ts
+++ b/frontend/src/lib/metrics/index.ts
@@ -6,6 +6,7 @@ export type {
   TrendMethod,
   TrendMode,
   TrendModeConfig,
+  ViewMode,
   AccumulatingMetricType,
   MetricAggregation,
   MetricName,

--- a/frontend/src/lib/metrics/service.ts
+++ b/frontend/src/lib/metrics/service.ts
@@ -46,33 +46,57 @@ import { METRIC_REGISTRY, resolveMetric, getMetricByKey } from "./registry";
 import { DASHBOARD_METRIC_KEYS } from "./keys";
 
 export const TREND_MODES: Record<TrendMode, TrendModeConfig> = {
-  short: {
-    label: "Short",
+  recent: {
+    label: "6W",
+    rangeDays: 42,
     shortTerm: 7,
-    baseline: 84,
+    longTerm: 14,
+    baseline: 42,
     trendWindow: 7,
+    bandwidthShort: 0.17,
+    bandwidthLong: 0.33,
     useShiftedZScore: false,
-    description: "7d vs 12w",
+    description: "Daily",
   },
-  mid: {
-    label: "Mid",
-    shortTerm: 28,
-    baseline: 252,
+  quarter: {
+    label: "6M",
+    rangeDays: 180,
+    shortTerm: 14,
+    longTerm: 30,
+    baseline: 90,
     trendWindow: 14,
+    bandwidthShort: 0.08,
+    bandwidthLong: 0.17,
     useShiftedZScore: true,
-    description: "4w vs 9mo",
+    description: "Training",
   },
-  long: {
-    label: "Long",
-    shortTerm: 90,
-    baseline: 730,
+  year: {
+    label: "2Y",
+    rangeDays: 730,
+    shortTerm: 30,
+    longTerm: 90,
+    baseline: 180,
     trendWindow: 30,
+    bandwidthShort: 0.04,
+    bandwidthLong: 0.12,
     useShiftedZScore: true,
-    description: "90d vs 2yr",
+    description: "Seasonal",
+  },
+  all: {
+    label: "5Y",
+    rangeDays: 1825,
+    shortTerm: 90,
+    longTerm: 180,
+    baseline: 365,
+    trendWindow: 60,
+    bandwidthShort: 0.05,
+    bandwidthLong: 0.1,
+    useShiftedZScore: true,
+    description: "Lifetime",
   },
 };
 
-export const MODE_ORDER: TrendMode[] = ["short", "mid", "long"];
+export const MODE_ORDER: TrendMode[] = ["recent", "quarter", "year", "all"];
 
 function aggregationMethodFromDef(
   def: MetricDef,

--- a/frontend/src/lib/metrics/types.ts
+++ b/frontend/src/lib/metrics/types.ts
@@ -71,13 +71,18 @@ export interface TrendConfig {
   colorVar: string;
 }
 
-export type TrendMode = "short" | "mid" | "long";
+export type TrendMode = "recent" | "quarter" | "year" | "all";
+export type ViewMode = TrendMode | "today" | "custom";
 
 export interface TrendModeConfig {
   label: string;
+  rangeDays: number;
   shortTerm: number;
+  longTerm: number;
   baseline: number;
   trendWindow: number;
+  bandwidthShort: number;
+  bandwidthLong: number;
   useShiftedZScore: boolean;
   description: string;
 }

--- a/frontend/src/lib/statistics.ts
+++ b/frontend/src/lib/statistics.ts
@@ -271,3 +271,75 @@ export function calculateBiologicalWeightSmoothing<
     };
   });
 }
+
+export interface LoessPoint {
+  x: number;
+  y: number;
+  index: number;
+}
+
+const tricube = (d: number): number => {
+  const absD = Math.abs(d);
+  return absD < 1 ? Math.pow(1 - Math.pow(absD, 3), 3) : 0;
+};
+
+export function loessSmooth<
+  T extends { date: string } & Record<string, unknown>,
+>(
+  data: T[],
+  valueKey: keyof T,
+  bandwidth: number = 0.25,
+): (T & { loess: number | null })[] {
+  const points: LoessPoint[] = [];
+
+  for (let i = 0; i < data.length; i++) {
+    const val = data[i][valueKey] as number | null;
+    if (val !== null) {
+      points.push({
+        x: new Date(data[i].date).getTime(),
+        y: val,
+        index: i,
+      });
+    }
+  }
+
+  if (points.length < 3) {
+    return data.map((d) => ({ ...d, loess: d[valueKey] as number | null }));
+  }
+
+  const windowSize = Math.max(3, Math.floor(points.length * bandwidth));
+  const smoothed = new Map<number, number>();
+
+  for (const target of points) {
+    const distances = points
+      .map((p) => ({ p, dist: Math.abs(p.x - target.x) }))
+      .sort((a, b) => a.dist - b.dist)
+      .slice(0, windowSize);
+
+    const maxDist = distances[distances.length - 1].dist || 1;
+
+    let sumW = 0,
+      sumWX = 0,
+      sumWY = 0,
+      sumWXX = 0,
+      sumWXY = 0;
+
+    for (const { p, dist } of distances) {
+      const w = tricube(dist / maxDist);
+      const dx = p.x - target.x;
+      sumW += w;
+      sumWX += w * dx;
+      sumWY += w * p.y;
+      sumWXX += w * dx * dx;
+      sumWXY += w * dx * p.y;
+    }
+
+    const denom = sumW * sumWXX - sumWX * sumWX;
+    smoothed.set(
+      target.index,
+      denom !== 0 ? (sumWXX * sumWY - sumWX * sumWXY) / denom : sumWY / sumW,
+    );
+  }
+
+  return data.map((d, i) => ({ ...d, loess: smoothed.get(i) ?? null }));
+}

--- a/src/pull_garmin_data.py
+++ b/src/pull_garmin_data.py
@@ -80,7 +80,7 @@ def init_api(email: str, password: str, user_id: int) -> Garmin:
         raise
 
 
-GARMIN_MAX_HISTORY_DAYS = 730  # ~2 years for health data
+GARMIN_MAX_HISTORY_DAYS = 1825  # ~5 years for health data
 GARMIN_API_RATE_LIMIT_DELAY = 0.5  # seconds between API calls to avoid rate limiting
 GARMIN_MAX_RETRIES = 3
 


### PR DESCRIPTION
## Summary

- Switch all charts from EMA to LOESS algorithm for better handling of data gaps
- Reduce trend lines from 3 to 2 (short + long) for cleaner visualization
- Add dynamic bandwidth props to all chart components based on selected mode
- Extend backend history limit from 2 to 5 years (1825 days)

## Mode Configuration

| Mode | Range | Short Trend | Long Trend | Use Case |
|------|-------|-------------|------------|----------|
| 6W | 42 days | ~7 days (17%) | ~14 days (33%) | Daily monitoring |
| 6M | 180 days | ~14 days (8%) | ~30 days (17%) | Training cycles |
| 2Y | 730 days | ~30 days (4%) | ~90 days (12%) | Seasonal patterns |
| 5Y | 1825 days | ~90 days (5%) | ~180 days (10%) | Long-term trends |

## Changes

**Frontend:**
- All chart components now accept `bandwidthShort` and `bandwidthLong` props
- `useTrendData` hook updated to use LOESS with configurable bandwidth
- Unified field names to `trendShort`/`trendLong` across codebase
- `TrendLines.tsx` reduced to 2 lines

**Backend:**
- `GARMIN_MAX_HISTORY_DAYS` increased from 730 to 1825 days

## Test plan

- [ ] Verify charts render correctly with LOESS smoothing
- [ ] Test all time range modes (6W, 6M, 2Y, 5Y)
- [ ] Confirm trend lines adapt to selected mode
- [ ] Check data with gaps is handled smoothly