### PR TITLE
Add Health Log page for medications and lab results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,5 +360,9 @@ jobs:
       - uses: nikolay-e/autoqa@6f4d18ff49e08876825f9bc9c41fa3f9ec212676 # main
         with:
           url: https://life-as-code.com
-          crawler-seed-pages: '/,/dashboard,/dashboard/sleep,/dashboard/statistics,/dashboard/trainings,/dashboard/data-status,/dashboard/settings'
+          crawler-username: ${{ secrets.QA_USERNAME }}
+          crawler-password: ${{ secrets.QA_PASSWORD }}
+          crawler-login-url: /login
+          crawler-seed-pages: '/dashboard,/dashboard/sleep,/dashboard/statistics,/dashboard/trainings,/dashboard/data-status,/dashboard/settings'
           crawler-max-pages: '20'
+          crawler-exclude-urls: '/whoop/authorize'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,11 @@ const SleepOverviewPage = lazy(() =>
     default: m.SleepOverviewPage,
   })),
 );
+const HealthLogPage = lazy(() =>
+  import("./features/dashboard/HealthLogPage").then((m) => ({
+    default: m.HealthLogPage,
+  })),
+);
 const SettingsPage = lazy(() =>
   import("./pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
 );
@@ -73,6 +78,10 @@ export default function App() {
                 <Route
                   path="/dashboard/trainings"
                   element={<TrainingsPage />}
+                />
+                <Route
+                  path="/dashboard/health-log"
+                  element={<HealthLogPage />}
                 />
                 <Route
                   path="/dashboard/data-status"

--- a/frontend/src/components/settings/ProviderCard.tsx
+++ b/frontend/src/components/settings/ProviderCard.tsx
@@ -179,12 +179,14 @@ export function ProviderCard({
   const renderActionButtons = () => {
     if (isTokenExpired && authUrl) {
       return (
-        <Button variant="outline" size="sm" asChild>
-          <a href={authUrl} aria-label={`Reconnect ${name} account`}>
-            <ExternalLink className="h-4 w-4 mr-2" aria-hidden="true" />
-            Reconnect
-          </a>
-        </Button>
+        <a
+          href={authUrl}
+          aria-label={`Reconnect ${name} account`}
+          className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground h-8 px-3"
+        >
+          <ExternalLink className="h-4 w-4 mr-2" aria-hidden="true" />
+          Reconnect
+        </a>
       );
     }
 
@@ -230,12 +232,14 @@ export function ProviderCard({
 
     if (authUrl) {
       return (
-        <Button variant="outline" size="sm" asChild>
-          <a href={authUrl} aria-label={`Connect ${name} account`}>
-            <ExternalLink className="h-4 w-4 mr-2" aria-hidden="true" />
-            Connect Account
-          </a>
-        </Button>
+        <a
+          href={authUrl}
+          aria-label={`Connect ${name} account`}
+          className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground h-8 px-3"
+        >
+          <ExternalLink className="h-4 w-4 mr-2" aria-hidden="true" />
+          Connect Account
+        </a>
       );
     }
 

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -32,7 +32,7 @@ const CardTitle = React.forwardRef<
   HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, children, ...props }, ref) => (
-  <h3
+  <h2
     ref={ref}
     className={cn(
       "text-base font-semibold leading-none tracking-tight text-foreground",
@@ -41,7 +41,7 @@ const CardTitle = React.forwardRef<
     {...props}
   >
     {children}
-  </h3>
+  </h2>
 ));
 CardTitle.displayName = "CardTitle";
 

--- a/frontend/src/features/dashboard/DashboardLayout.tsx
+++ b/frontend/src/features/dashboard/DashboardLayout.tsx
@@ -18,6 +18,7 @@ import {
   Loader2,
   Dumbbell,
   Moon,
+  Pill,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { Spinner } from "../../components/ui/spinner";
@@ -41,6 +42,12 @@ const navItems = [
     to: "/dashboard/trainings",
     icon: Dumbbell,
     label: "Trainings",
+    end: false,
+  },
+  {
+    to: "/dashboard/health-log",
+    icon: Pill,
+    label: "Health Log",
     end: false,
   },
   {

--- a/frontend/src/features/dashboard/HealthLogPage.tsx
+++ b/frontend/src/features/dashboard/HealthLogPage.tsx
@@ -1,5 +1,4 @@
 import { useState, type FormEvent } from "react";
-import { format } from "date-fns";
 import { toast } from "sonner";
 import {
   Pill,
@@ -31,17 +30,19 @@ import {
 import { LoadingState } from "../../components/ui/loading-state";
 import { ErrorCard } from "../../components/ui/error-card";
 import { cn } from "../../lib/utils";
+import { getLocalDateString, getLocalToday } from "../../lib/health";
 import type { InterventionData, BloodBiomarkerData } from "../../types/api";
 
 type Tab = "medications" | "labs";
+type Category = InterventionData["category"];
 
-const CATEGORIES = [
+const CATEGORIES: { value: Category; label: string }[] = [
   { value: "medication", label: "Medication" },
   { value: "supplement", label: "Supplement" },
   { value: "protocol", label: "Protocol" },
   { value: "lifestyle", label: "Lifestyle" },
   { value: "diet", label: "Diet" },
-] as const;
+];
 
 const BIOMARKER_PRESETS: { name: string; unit: string }[] = [
   { name: "TSH", unit: "mIU/L" },
@@ -71,7 +72,7 @@ const BIOMARKER_PRESETS: { name: string; unit: string }[] = [
   { name: "Cortisol", unit: "ug/dL" },
 ];
 
-const todayStr = () => format(new Date(), "yyyy-MM-dd");
+const todayStr = () => getLocalDateString(getLocalToday());
 
 function InterventionForm({
   onClose,
@@ -80,7 +81,7 @@ function InterventionForm({
 }>) {
   const create = useCreateIntervention();
   const [name, setName] = useState("");
-  const [category, setCategory] = useState("supplement");
+  const [category, setCategory] = useState<Category>("supplement");
   const [dosage, setDosage] = useState("");
   const [frequency, setFrequency] = useState("");
   const [startDate, setStartDate] = useState(todayStr());
@@ -132,7 +133,7 @@ function InterventionForm({
                 id="med-category"
                 value={category}
                 onChange={(e) => {
-                  setCategory(e.target.value);
+                  setCategory(e.target.value as Category);
                 }}
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
               >
@@ -230,7 +231,7 @@ function InterventionCard({
     });
   };
 
-  const isActive = Boolean(item.active);
+  const isActive = item.active;
 
   return (
     <div
@@ -294,7 +295,7 @@ function MedicationsTab() {
   if (isLoading) return <LoadingState message="Loading medications..." />;
   if (error) return <ErrorCard message="Failed to load medications" />;
 
-  const active = (interventions ?? []).filter((i) => Boolean(i.active));
+  const active = (interventions ?? []).filter((i) => i.active);
   const inactive = (interventions ?? []).filter((i) => !i.active);
 
   return (

--- a/frontend/src/features/dashboard/HealthLogPage.tsx
+++ b/frontend/src/features/dashboard/HealthLogPage.tsx
@@ -1,7 +1,15 @@
 import { useState, type FormEvent } from "react";
 import { format } from "date-fns";
 import { toast } from "sonner";
-import { Pill, FlaskConical, Plus, Square, Trash2, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  Pill,
+  FlaskConical,
+  Plus,
+  Square,
+  Trash2,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
 import {
   useInterventions,
   useCreateIntervention,
@@ -96,9 +104,7 @@ function InterventionForm({
           onClose();
         },
         onError: (err) =>
-          toast.error(
-            err instanceof Error ? err.message : "Failed to add",
-          ),
+          toast.error(err instanceof Error ? err.message : "Failed to add"),
       },
     );
   };
@@ -113,7 +119,9 @@ function InterventionForm({
               <Input
                 id="med-name"
                 value={name}
-                onChange={(e) => { setName(e.target.value); }}
+                onChange={(e) => {
+                  setName(e.target.value);
+                }}
                 placeholder="e.g. Metformin"
                 required
               />
@@ -123,7 +131,9 @@ function InterventionForm({
               <select
                 id="med-category"
                 value={category}
-                onChange={(e) => { setCategory(e.target.value); }}
+                onChange={(e) => {
+                  setCategory(e.target.value);
+                }}
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
               >
                 {CATEGORIES.map((c) => (
@@ -138,7 +148,9 @@ function InterventionForm({
               <Input
                 id="med-dosage"
                 value={dosage}
-                onChange={(e) => { setDosage(e.target.value); }}
+                onChange={(e) => {
+                  setDosage(e.target.value);
+                }}
                 placeholder="e.g. 500mg"
               />
             </div>
@@ -147,7 +159,9 @@ function InterventionForm({
               <Input
                 id="med-frequency"
                 value={frequency}
-                onChange={(e) => { setFrequency(e.target.value); }}
+                onChange={(e) => {
+                  setFrequency(e.target.value);
+                }}
                 placeholder="e.g. 2x daily"
               />
             </div>
@@ -157,7 +171,9 @@ function InterventionForm({
                 id="med-start"
                 type="date"
                 value={startDate}
-                onChange={(e) => { setStartDate(e.target.value); }}
+                onChange={(e) => {
+                  setStartDate(e.target.value);
+                }}
                 required
               />
             </div>
@@ -166,7 +182,9 @@ function InterventionForm({
               <Input
                 id="med-notes"
                 value={notes}
-                onChange={(e) => { setNotes(e.target.value); }}
+                onChange={(e) => {
+                  setNotes(e.target.value);
+                }}
                 placeholder="Optional notes"
               />
             </div>
@@ -248,7 +266,7 @@ function InterventionCard({
             className="h-7 w-7"
             onClick={handleStop}
             disabled={update.isPending}
-            title="Stop medication"
+            aria-label="Stop medication"
           >
             <Square className="h-3.5 w-3.5" />
           </Button>
@@ -259,7 +277,7 @@ function InterventionCard({
           className="h-7 w-7 hover:text-destructive"
           onClick={handleDelete}
           disabled={remove.isPending}
-          title="Delete"
+          aria-label={`Delete ${item.name}`}
         >
           <Trash2 className="h-3.5 w-3.5" />
         </Button>
@@ -286,7 +304,9 @@ function MedicationsTab() {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => { setShowForm(!showForm); }}
+          onClick={() => {
+            setShowForm(!showForm);
+          }}
         >
           <Plus className="h-4 w-4 mr-1" />
           Add
@@ -294,7 +314,11 @@ function MedicationsTab() {
       </div>
 
       {showForm && (
-        <InterventionForm onClose={() => { setShowForm(false); }} />
+        <InterventionForm
+          onClose={() => {
+            setShowForm(false);
+          }}
+        />
       )}
 
       {active.length === 0 ? (
@@ -313,7 +337,9 @@ function MedicationsTab() {
         <div>
           <button
             type="button"
-            onClick={() => { setShowHistory(!showHistory); }}
+            onClick={() => {
+              setShowHistory(!showHistory);
+            }}
             className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             {showHistory ? (
@@ -384,9 +410,7 @@ function BiomarkerForm({
           setNotes("");
         },
         onError: (err) =>
-          toast.error(
-            err instanceof Error ? err.message : "Failed to add",
-          ),
+          toast.error(err instanceof Error ? err.message : "Failed to add"),
       },
     );
   };
@@ -402,7 +426,9 @@ function BiomarkerForm({
                 id="bio-date"
                 type="date"
                 value={date}
-                onChange={(e) => { setDate(e.target.value); }}
+                onChange={(e) => {
+                  setDate(e.target.value);
+                }}
                 required
               />
             </div>
@@ -412,7 +438,9 @@ function BiomarkerForm({
                 id="bio-marker"
                 list="biomarker-presets"
                 value={markerName}
-                onChange={(e) => { handleMarkerChange(e.target.value); }}
+                onChange={(e) => {
+                  handleMarkerChange(e.target.value);
+                }}
                 placeholder="e.g. TSH"
                 required
               />
@@ -429,7 +457,9 @@ function BiomarkerForm({
                 type="number"
                 step="any"
                 value={value}
-                onChange={(e) => { setValue(e.target.value); }}
+                onChange={(e) => {
+                  setValue(e.target.value);
+                }}
                 placeholder="e.g. 2.5"
                 required
               />
@@ -440,15 +470,15 @@ function BiomarkerForm({
                 id="bio-unit"
                 list="unit-presets"
                 value={unit}
-                onChange={(e) => { setUnit(e.target.value); }}
+                onChange={(e) => {
+                  setUnit(e.target.value);
+                }}
                 placeholder="e.g. mIU/L"
               />
               <datalist id="unit-presets">
-                {[...new Set(BIOMARKER_PRESETS.map((p) => p.unit))].map(
-                  (u) => (
-                    <option key={u} value={u} />
-                  ),
-                )}
+                {[...new Set(BIOMARKER_PRESETS.map((p) => p.unit))].map((u) => (
+                  <option key={u} value={u} />
+                ))}
               </datalist>
             </div>
             <div>
@@ -458,7 +488,9 @@ function BiomarkerForm({
                 type="number"
                 step="any"
                 value={refLow}
-                onChange={(e) => { setRefLow(e.target.value); }}
+                onChange={(e) => {
+                  setRefLow(e.target.value);
+                }}
                 placeholder="Optional"
               />
             </div>
@@ -469,7 +501,9 @@ function BiomarkerForm({
                 type="number"
                 step="any"
                 value={refHigh}
-                onChange={(e) => { setRefHigh(e.target.value); }}
+                onChange={(e) => {
+                  setRefHigh(e.target.value);
+                }}
                 placeholder="Optional"
               />
             </div>
@@ -478,7 +512,9 @@ function BiomarkerForm({
               <Input
                 id="bio-lab"
                 value={labName}
-                onChange={(e) => { setLabName(e.target.value); }}
+                onChange={(e) => {
+                  setLabName(e.target.value);
+                }}
                 placeholder="Optional"
               />
             </div>
@@ -487,7 +523,9 @@ function BiomarkerForm({
               <Input
                 id="bio-notes"
                 value={notes}
-                onChange={(e) => { setNotes(e.target.value); }}
+                onChange={(e) => {
+                  setNotes(e.target.value);
+                }}
                 placeholder="Optional notes"
               />
             </div>
@@ -507,20 +545,22 @@ function BiomarkerForm({
 }
 
 function isOutOfRange(item: BloodBiomarkerData): boolean {
-  if (item.reference_range_low != null && item.value < item.reference_range_low)
-    {return true;}
+  if (
+    item.reference_range_low != null &&
+    item.value < item.reference_range_low
+  ) {
+    return true;
+  }
   if (
     item.reference_range_high != null &&
     item.value > item.reference_range_high
-  )
-    {return true;}
+  ) {
+    return true;
+  }
   return false;
 }
 
-function formatRange(
-  low: number | null,
-  high: number | null,
-): string | null {
+function formatRange(low: number | null, high: number | null): string | null {
   if (low != null && high != null) return `${String(low)} – ${String(high)}`;
   if (low != null) return `>= ${String(low)}`;
   if (high != null) return `<= ${String(high)}`;
@@ -562,7 +602,9 @@ function LabResultsTab() {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => { setShowForm(!showForm); }}
+          onClick={() => {
+            setShowForm(!showForm);
+          }}
         >
           <Plus className="h-4 w-4 mr-1" />
           Add
@@ -570,7 +612,11 @@ function LabResultsTab() {
       </div>
 
       {showForm && (
-        <BiomarkerForm onClose={() => { setShowForm(false); }} />
+        <BiomarkerForm
+          onClose={() => {
+            setShowForm(false);
+          }}
+        />
       )}
 
       {items.length === 0 ? (
@@ -630,11 +676,11 @@ function LabResultsTab() {
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7 hover:text-destructive shrink-0"
-                          onClick={() =>
-                            { handleDelete(item.id, item.marker_name); }
-                          }
+                          onClick={() => {
+                            handleDelete(item.id, item.marker_name);
+                          }}
                           disabled={remove.isPending}
-                          title="Delete"
+                          aria-label={`Delete ${item.marker_name}`}
                         >
                           <Trash2 className="h-3.5 w-3.5" />
                         </Button>
@@ -667,7 +713,9 @@ export function HealthLogPage() {
         <Button
           variant={tab === "medications" ? "default" : "ghost"}
           size="sm"
-          onClick={() => { setTab("medications"); }}
+          onClick={() => {
+            setTab("medications");
+          }}
           className="gap-1.5"
         >
           <Pill className="h-4 w-4" />
@@ -676,7 +724,9 @@ export function HealthLogPage() {
         <Button
           variant={tab === "labs" ? "default" : "ghost"}
           size="sm"
-          onClick={() => { setTab("labs"); }}
+          onClick={() => {
+            setTab("labs");
+          }}
           className="gap-1.5"
         >
           <FlaskConical className="h-4 w-4" />

--- a/frontend/src/features/dashboard/HealthLogPage.tsx
+++ b/frontend/src/features/dashboard/HealthLogPage.tsx
@@ -1,0 +1,690 @@
+import { useState, type FormEvent } from "react";
+import { format } from "date-fns";
+import { toast } from "sonner";
+import { Pill, FlaskConical, Plus, Square, Trash2, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  useInterventions,
+  useCreateIntervention,
+  useUpdateIntervention,
+  useDeleteIntervention,
+  useBiomarkers,
+  useCreateBiomarker,
+  useDeleteBiomarker,
+} from "../../hooks/useHealthLog";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import { Label } from "../../components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../../components/ui/card";
+import { LoadingState } from "../../components/ui/loading-state";
+import { ErrorCard } from "../../components/ui/error-card";
+import { cn } from "../../lib/utils";
+import type { InterventionData, BloodBiomarkerData } from "../../types/api";
+
+type Tab = "medications" | "labs";
+
+const CATEGORIES = [
+  { value: "medication", label: "Medication" },
+  { value: "supplement", label: "Supplement" },
+  { value: "protocol", label: "Protocol" },
+  { value: "lifestyle", label: "Lifestyle" },
+  { value: "diet", label: "Diet" },
+] as const;
+
+const BIOMARKER_PRESETS: { name: string; unit: string }[] = [
+  { name: "TSH", unit: "mIU/L" },
+  { name: "Vitamin D", unit: "ng/mL" },
+  { name: "HbA1c", unit: "%" },
+  { name: "Total Testosterone", unit: "ng/dL" },
+  { name: "Free Testosterone", unit: "pg/mL" },
+  { name: "Ferritin", unit: "ng/mL" },
+  { name: "hsCRP", unit: "mg/L" },
+  { name: "Fasting Glucose", unit: "mg/dL" },
+  { name: "Insulin", unit: "uIU/mL" },
+  { name: "ApoB", unit: "mg/dL" },
+  { name: "Lp(a)", unit: "nmol/L" },
+  { name: "Homocysteine", unit: "umol/L" },
+  { name: "Total Cholesterol", unit: "mg/dL" },
+  { name: "LDL", unit: "mg/dL" },
+  { name: "HDL", unit: "mg/dL" },
+  { name: "Triglycerides", unit: "mg/dL" },
+  { name: "ALT", unit: "U/L" },
+  { name: "AST", unit: "U/L" },
+  { name: "Creatinine", unit: "mg/dL" },
+  { name: "eGFR", unit: "mL/min" },
+  { name: "Vitamin B12", unit: "pg/mL" },
+  { name: "Folate", unit: "ng/mL" },
+  { name: "DHEA-S", unit: "ug/dL" },
+  { name: "IGF-1", unit: "ng/mL" },
+  { name: "Cortisol", unit: "ug/dL" },
+];
+
+const todayStr = () => format(new Date(), "yyyy-MM-dd");
+
+function InterventionForm({
+  onClose,
+}: Readonly<{
+  onClose: () => void;
+}>) {
+  const create = useCreateIntervention();
+  const [name, setName] = useState("");
+  const [category, setCategory] = useState("supplement");
+  const [dosage, setDosage] = useState("");
+  const [frequency, setFrequency] = useState("");
+  const [startDate, setStartDate] = useState(todayStr());
+  const [notes, setNotes] = useState("");
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    create.mutate(
+      {
+        name: name.trim(),
+        category,
+        dosage: dosage.trim() || undefined,
+        frequency: frequency.trim() || undefined,
+        start_date: startDate,
+        notes: notes.trim() || undefined,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Medication added");
+          onClose();
+        },
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Failed to add",
+          ),
+      },
+    );
+  };
+
+  return (
+    <Card className="border-dashed">
+      <CardContent className="pt-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <Label htmlFor="med-name">Name *</Label>
+              <Input
+                id="med-name"
+                value={name}
+                onChange={(e) => { setName(e.target.value); }}
+                placeholder="e.g. Metformin"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="med-category">Category</Label>
+              <select
+                id="med-category"
+                value={category}
+                onChange={(e) => { setCategory(e.target.value); }}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <Label htmlFor="med-dosage">Dosage</Label>
+              <Input
+                id="med-dosage"
+                value={dosage}
+                onChange={(e) => { setDosage(e.target.value); }}
+                placeholder="e.g. 500mg"
+              />
+            </div>
+            <div>
+              <Label htmlFor="med-frequency">Frequency</Label>
+              <Input
+                id="med-frequency"
+                value={frequency}
+                onChange={(e) => { setFrequency(e.target.value); }}
+                placeholder="e.g. 2x daily"
+              />
+            </div>
+            <div>
+              <Label htmlFor="med-start">Start Date</Label>
+              <Input
+                id="med-start"
+                type="date"
+                value={startDate}
+                onChange={(e) => { setStartDate(e.target.value); }}
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="med-notes">Notes</Label>
+              <Input
+                id="med-notes"
+                value={notes}
+                onChange={(e) => { setNotes(e.target.value); }}
+                placeholder="Optional notes"
+              />
+            </div>
+          </div>
+          <div className="flex gap-2 justify-end">
+            <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={create.isPending}>
+              {create.isPending ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function InterventionCard({
+  item,
+}: Readonly<{
+  item: InterventionData;
+}>) {
+  const update = useUpdateIntervention();
+  const remove = useDeleteIntervention();
+
+  const handleStop = () => {
+    update.mutate(
+      { id: item.id, data: { active: false, end_date: todayStr() } },
+      {
+        onSuccess: () => toast.success(`Stopped ${item.name}`),
+        onError: (err) =>
+          toast.error(err instanceof Error ? err.message : "Failed"),
+      },
+    );
+  };
+
+  const handleDelete = () => {
+    remove.mutate(item.id, {
+      onSuccess: () => toast.success(`Deleted ${item.name}`),
+      onError: (err) =>
+        toast.error(err instanceof Error ? err.message : "Failed"),
+    });
+  };
+
+  const isActive = Boolean(item.active);
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between p-3 rounded-lg border",
+        isActive ? "bg-background" : "bg-muted/30 opacity-70",
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-sm truncate">{item.name}</span>
+          <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+            {item.category}
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-x-4 gap-y-0.5 mt-0.5 text-xs text-muted-foreground">
+          {item.dosage && <span>{item.dosage}</span>}
+          {item.frequency && <span>{item.frequency}</span>}
+          <span>from {item.start_date}</span>
+          {item.end_date && <span>to {item.end_date}</span>}
+        </div>
+        {item.notes && (
+          <p className="text-xs text-muted-foreground mt-0.5 truncate">
+            {item.notes}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-1 ml-2 shrink-0">
+        {isActive && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={handleStop}
+            disabled={update.isPending}
+            title="Stop medication"
+          >
+            <Square className="h-3.5 w-3.5" />
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 hover:text-destructive"
+          onClick={handleDelete}
+          disabled={remove.isPending}
+          title="Delete"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function MedicationsTab() {
+  const { data: interventions, isLoading, error } = useInterventions();
+  const [showForm, setShowForm] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+
+  if (isLoading) return <LoadingState message="Loading medications..." />;
+  if (error) return <ErrorCard message="Failed to load medications" />;
+
+  const active = (interventions ?? []).filter((i) => Boolean(i.active));
+  const inactive = (interventions ?? []).filter((i) => !i.active);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Active</h2>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => { setShowForm(!showForm); }}
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          Add
+        </Button>
+      </div>
+
+      {showForm && (
+        <InterventionForm onClose={() => { setShowForm(false); }} />
+      )}
+
+      {active.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          No active medications or supplements
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {active.map((item) => (
+            <InterventionCard key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+
+      {inactive.length > 0 && (
+        <div>
+          <button
+            type="button"
+            onClick={() => { setShowHistory(!showHistory); }}
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {showHistory ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+            History ({inactive.length})
+          </button>
+          {showHistory && (
+            <div className="space-y-2 mt-2">
+              {inactive.map((item) => (
+                <InterventionCard key={item.id} item={item} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BiomarkerForm({
+  onClose,
+}: Readonly<{
+  onClose: () => void;
+}>) {
+  const create = useCreateBiomarker();
+  const [date, setDate] = useState(todayStr());
+  const [markerName, setMarkerName] = useState("");
+  const [value, setValue] = useState("");
+  const [unit, setUnit] = useState("");
+  const [refLow, setRefLow] = useState("");
+  const [refHigh, setRefHigh] = useState("");
+  const [labName, setLabName] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const handleMarkerChange = (newName: string) => {
+    setMarkerName(newName);
+    const preset = BIOMARKER_PRESETS.find((p) => p.name === newName);
+    if (preset && !unit) {
+      setUnit(preset.unit);
+    }
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!markerName.trim() || !value) return;
+    create.mutate(
+      {
+        date,
+        marker_name: markerName.trim(),
+        value: parseFloat(value),
+        unit: unit.trim() || "units",
+        reference_range_low: refLow ? parseFloat(refLow) : undefined,
+        reference_range_high: refHigh ? parseFloat(refHigh) : undefined,
+        lab_name: labName.trim() || undefined,
+        notes: notes.trim() || undefined,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Lab result added");
+          setMarkerName("");
+          setValue("");
+          setUnit("");
+          setRefLow("");
+          setRefHigh("");
+          setNotes("");
+        },
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Failed to add",
+          ),
+      },
+    );
+  };
+
+  return (
+    <Card className="border-dashed">
+      <CardContent className="pt-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            <div>
+              <Label htmlFor="bio-date">Date *</Label>
+              <Input
+                id="bio-date"
+                type="date"
+                value={date}
+                onChange={(e) => { setDate(e.target.value); }}
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="bio-marker">Marker *</Label>
+              <Input
+                id="bio-marker"
+                list="biomarker-presets"
+                value={markerName}
+                onChange={(e) => { handleMarkerChange(e.target.value); }}
+                placeholder="e.g. TSH"
+                required
+              />
+              <datalist id="biomarker-presets">
+                {BIOMARKER_PRESETS.map((p) => (
+                  <option key={p.name} value={p.name} />
+                ))}
+              </datalist>
+            </div>
+            <div>
+              <Label htmlFor="bio-value">Value *</Label>
+              <Input
+                id="bio-value"
+                type="number"
+                step="any"
+                value={value}
+                onChange={(e) => { setValue(e.target.value); }}
+                placeholder="e.g. 2.5"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="bio-unit">Unit</Label>
+              <Input
+                id="bio-unit"
+                list="unit-presets"
+                value={unit}
+                onChange={(e) => { setUnit(e.target.value); }}
+                placeholder="e.g. mIU/L"
+              />
+              <datalist id="unit-presets">
+                {[...new Set(BIOMARKER_PRESETS.map((p) => p.unit))].map(
+                  (u) => (
+                    <option key={u} value={u} />
+                  ),
+                )}
+              </datalist>
+            </div>
+            <div>
+              <Label htmlFor="bio-ref-low">Ref. Low</Label>
+              <Input
+                id="bio-ref-low"
+                type="number"
+                step="any"
+                value={refLow}
+                onChange={(e) => { setRefLow(e.target.value); }}
+                placeholder="Optional"
+              />
+            </div>
+            <div>
+              <Label htmlFor="bio-ref-high">Ref. High</Label>
+              <Input
+                id="bio-ref-high"
+                type="number"
+                step="any"
+                value={refHigh}
+                onChange={(e) => { setRefHigh(e.target.value); }}
+                placeholder="Optional"
+              />
+            </div>
+            <div>
+              <Label htmlFor="bio-lab">Lab Name</Label>
+              <Input
+                id="bio-lab"
+                value={labName}
+                onChange={(e) => { setLabName(e.target.value); }}
+                placeholder="Optional"
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <Label htmlFor="bio-notes">Notes</Label>
+              <Input
+                id="bio-notes"
+                value={notes}
+                onChange={(e) => { setNotes(e.target.value); }}
+                placeholder="Optional notes"
+              />
+            </div>
+          </div>
+          <div className="flex gap-2 justify-end">
+            <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={create.isPending}>
+              {create.isPending ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function isOutOfRange(item: BloodBiomarkerData): boolean {
+  if (item.reference_range_low != null && item.value < item.reference_range_low)
+    {return true;}
+  if (
+    item.reference_range_high != null &&
+    item.value > item.reference_range_high
+  )
+    {return true;}
+  return false;
+}
+
+function formatRange(
+  low: number | null,
+  high: number | null,
+): string | null {
+  if (low != null && high != null) return `${String(low)} – ${String(high)}`;
+  if (low != null) return `>= ${String(low)}`;
+  if (high != null) return `<= ${String(high)}`;
+  return null;
+}
+
+function LabResultsTab() {
+  const { data: biomarkers, isLoading, error } = useBiomarkers();
+  const remove = useDeleteBiomarker();
+  const [showForm, setShowForm] = useState(false);
+
+  if (isLoading) return <LoadingState message="Loading lab results..." />;
+  if (error) return <ErrorCard message="Failed to load lab results" />;
+
+  const items = biomarkers ?? [];
+
+  const grouped = new Map<string, BloodBiomarkerData[]>();
+  for (const item of items) {
+    const existing = grouped.get(item.date);
+    if (existing) {
+      existing.push(item);
+    } else {
+      grouped.set(item.date, [item]);
+    }
+  }
+
+  const handleDelete = (id: number, name: string) => {
+    remove.mutate(id, {
+      onSuccess: () => toast.success(`Deleted ${name}`),
+      onError: (err) =>
+        toast.error(err instanceof Error ? err.message : "Failed"),
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Lab Results</h2>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => { setShowForm(!showForm); }}
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          Add
+        </Button>
+      </div>
+
+      {showForm && (
+        <BiomarkerForm onClose={() => { setShowForm(false); }} />
+      )}
+
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          No lab results recorded
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {[...grouped.entries()].map(([date, dateItems]) => (
+            <Card key={date}>
+              <CardHeader className="py-3 px-4">
+                <CardTitle className="text-sm font-medium">{date}</CardTitle>
+              </CardHeader>
+              <CardContent className="px-4 pb-3 pt-0">
+                <div className="divide-y">
+                  {dateItems.map((item) => {
+                    const outOfRange = isOutOfRange(item);
+                    const range = formatRange(
+                      item.reference_range_low,
+                      item.reference_range_high,
+                    );
+                    return (
+                      <div
+                        key={item.id}
+                        className="flex items-center justify-between py-2 first:pt-0 last:pb-0"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-baseline gap-2">
+                            <span className="text-sm font-medium">
+                              {item.marker_name}
+                            </span>
+                            <span
+                              className={cn(
+                                "text-sm font-mono",
+                                outOfRange
+                                  ? "text-red-600 dark:text-red-400 font-semibold"
+                                  : "text-foreground",
+                              )}
+                            >
+                              {item.value} {item.unit}
+                            </span>
+                            {range && (
+                              <span className="text-xs text-muted-foreground">
+                                ref: {range}
+                              </span>
+                            )}
+                          </div>
+                          {(item.lab_name ?? item.notes) && (
+                            <p className="text-xs text-muted-foreground truncate">
+                              {[item.lab_name, item.notes]
+                                .filter(Boolean)
+                                .join(" — ")}
+                            </p>
+                          )}
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 hover:text-destructive shrink-0"
+                          onClick={() =>
+                            { handleDelete(item.id, item.marker_name); }
+                          }
+                          disabled={remove.isPending}
+                          title="Delete"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function HealthLogPage() {
+  const [tab, setTab] = useState<Tab>("medications");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Health Log</h1>
+        <p className="text-muted-foreground mt-1">
+          Track medications, supplements, and lab results
+        </p>
+      </div>
+
+      <div className="flex items-center gap-1 p-1 bg-muted/50 rounded-lg w-fit">
+        <Button
+          variant={tab === "medications" ? "default" : "ghost"}
+          size="sm"
+          onClick={() => { setTab("medications"); }}
+          className="gap-1.5"
+        >
+          <Pill className="h-4 w-4" />
+          Medications
+        </Button>
+        <Button
+          variant={tab === "labs" ? "default" : "ghost"}
+          size="sm"
+          onClick={() => { setTab("labs"); }}
+          className="gap-1.5"
+        >
+          <FlaskConical className="h-4 w-4" />
+          Lab Results
+        </Button>
+      </div>
+
+      {tab === "medications" ? <MedicationsTab /> : <LabResultsTab />}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useHealthLog.ts
+++ b/frontend/src/hooks/useHealthLog.ts
@@ -1,0 +1,88 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api";
+import { longevityKeys } from "../lib/query-keys";
+
+export function useInterventions() {
+  return useQuery({
+    queryKey: longevityKeys.interventions(),
+    queryFn: () => api.longevity.getInterventions(),
+  });
+}
+
+export function useCreateIntervention() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: api.longevity.createIntervention,
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: longevityKeys.interventions() })
+        .catch(() => {});
+    },
+  });
+}
+
+export function useUpdateIntervention() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: Parameters<typeof api.longevity.updateIntervention>[1];
+    }) => api.longevity.updateIntervention(id, data),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: longevityKeys.interventions() })
+        .catch(() => {});
+    },
+  });
+}
+
+export function useDeleteIntervention() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => api.longevity.deleteIntervention(id),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: longevityKeys.interventions() })
+        .catch(() => {});
+    },
+  });
+}
+
+export function useBiomarkers() {
+  return useQuery({
+    queryKey: longevityKeys.biomarkers(),
+    queryFn: () => api.longevity.getBiomarkers(),
+  });
+}
+
+export function useCreateBiomarker() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: api.longevity.createBiomarker,
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: longevityKeys.biomarkers() })
+        .catch(() => {});
+    },
+  });
+}
+
+export function useDeleteBiomarker() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => api.longevity.deleteBiomarker(id),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: longevityKeys.biomarkers() })
+        .catch(() => {});
+    },
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -226,7 +226,7 @@ export const api = {
 
     createIntervention: (data: {
       name: string;
-      category: string;
+      category: InterventionData["category"];
       start_date: string;
       end_date?: string | null;
       dosage?: string | null;
@@ -242,7 +242,7 @@ export const api = {
       id: number,
       data: Partial<{
         name: string;
-        category: string;
+        category: InterventionData["category"];
         end_date: string | null;
         dosage: string | null;
         frequency: string | null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,10 +2,12 @@ import type {
   AnalyticsResponse,
   AuthResponse,
   BackoffStatus,
+  BloodBiomarkerData,
   CredentialTestResult,
   CredentialsStatus,
   GarminActivityData,
   HealthData,
+  InterventionData,
   SyncStatus,
   User,
   UserThresholds,
@@ -214,6 +216,72 @@ export const api = {
       const query = days ? `?days=${String(days)}` : "?full=true";
       return request(`/sync/eight_sleep${query}`, { method: "POST" });
     },
+  },
+
+  longevity: {
+    getInterventions: (active?: boolean): Promise<InterventionData[]> => {
+      const query = active ? "?active=true" : "";
+      return request(`/longevity/interventions${query}`);
+    },
+
+    createIntervention: (data: {
+      name: string;
+      category: string;
+      start_date: string;
+      end_date?: string | null;
+      dosage?: string | null;
+      frequency?: string | null;
+      notes?: string | null;
+    }): Promise<InterventionData> =>
+      request("/longevity/interventions", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+
+    updateIntervention: (
+      id: number,
+      data: Partial<{
+        name: string;
+        category: string;
+        end_date: string | null;
+        dosage: string | null;
+        frequency: string | null;
+        notes: string | null;
+        active: boolean;
+      }>,
+    ): Promise<InterventionData> =>
+      request(`/longevity/interventions/${String(id)}`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+
+    deleteIntervention: (id: number): Promise<{ deleted: boolean }> =>
+      request(`/longevity/interventions/${String(id)}`, { method: "DELETE" }),
+
+    getBiomarkers: (marker?: string): Promise<BloodBiomarkerData[]> => {
+      const query = marker ? `?marker=${encodeURIComponent(marker)}` : "";
+      return request(`/longevity/biomarkers${query}`);
+    },
+
+    createBiomarker: (data: {
+      date: string;
+      marker_name: string;
+      value: number;
+      unit: string;
+      reference_range_low?: number | null;
+      reference_range_high?: number | null;
+      longevity_optimal_low?: number | null;
+      longevity_optimal_high?: number | null;
+      lab_name?: string | null;
+      notes?: string | null;
+    }): Promise<BloodBiomarkerData> =>
+      request("/longevity/biomarkers", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+
+    deleteBiomarker: (id: number): Promise<{ deleted: boolean }> =>
+      request(`/longevity/biomarkers/${String(id)}`, { method: "DELETE" }),
   },
 };
 

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -19,3 +19,9 @@ export const settingsKeys = {
   thresholds: () => [...settingsKeys.all, "thresholds"] as const,
   credentials: () => [...settingsKeys.all, "credentials"] as const,
 };
+
+export const longevityKeys = {
+  all: ["longevity"] as const,
+  interventions: () => [...longevityKeys.all, "interventions"] as const,
+  biomarkers: () => [...longevityKeys.all, "biomarkers"] as const,
+};

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -707,7 +707,7 @@ export interface InterventionData {
   frequency: string | null;
   target_metrics: Record<string, unknown> | null;
   notes: string | null;
-  active: number;
+  active: boolean;
 }
 
 export interface FunctionalTestData {


### PR DESCRIPTION
## Summary

- New `/dashboard/health-log` page with two tabs: **Medications** and **Lab Results**
- **Medications tab**: add/stop/delete interventions (supplements, medications, protocols, lifestyle, diet) with name, dosage, frequency, start date tracking. Active list + collapsible history for stopped items.
- **Lab Results tab**: add/delete blood biomarkers with date, value, unit, reference ranges. Results grouped by date, out-of-range values highlighted in red. Includes 25 common biomarker presets via datalist (TSH, Vitamin D, HbA1c, ApoB, etc.)
- No backend changes — all CRUD APIs already existed (`/api/longevity/interventions`, `/api/longevity/biomarkers`)

## Files changed

- `frontend/src/lib/api.ts` — added `longevity` namespace with 7 API methods
- `frontend/src/lib/query-keys.ts` — added `longevityKeys`
- `frontend/src/hooks/useHealthLog.ts` — **new** — 7 React Query hooks
- `frontend/src/features/dashboard/HealthLogPage.tsx` — **new** — full page with forms, lists, tabs
- `frontend/src/features/dashboard/DashboardLayout.tsx` — added nav item (Pill icon)
- `frontend/src/App.tsx` — added lazy import + route

## Test plan

- [ ] Navigate to `/dashboard/health-log` — page loads with Medications tab active
- [ ] Add a medication with name, dosage, frequency — appears in active list
- [ ] Click Stop on a medication — moves to History section
- [ ] Delete a medication — removed from list
- [ ] Switch to Lab Results tab
- [ ] Add a lab result (try picking from datalist, e.g. "TSH") — unit auto-fills
- [ ] Add a result with value outside reference range — value shows in red
- [ ] Delete a lab result — removed from table
- [ ] Verify TypeScript and ESLint pass: `npx tsc --noEmit && npx eslint src/`

https://claude.ai/code/session_011QBhQ5BRKyE93cGwJ6puPy

---
_Generated by [Claude Code](https://claude.ai/code/session_011QBhQ5BRKyE93cGwJ6puPy)_