### PR TITLE
Restore missing metrics: Eight Sleep SFS, cause-aware UX, local Sleep Index

### DIFF
--- a/frontend/src/features/dashboard/statistics/LongevitySection.tsx
+++ b/frontend/src/features/dashboard/statistics/LongevitySection.tsx
@@ -104,14 +104,29 @@ export function LongevitySection({ longevityInsights }: LongevitySectionProps) {
                 },
               ].map(({ label, value }) => (
                 <div key={label} className="flex justify-between">
-                  <span className="text-xs text-muted-foreground">{label}</span>
+                  <span
+                    className="text-xs text-muted-foreground"
+                    title={
+                      value == null && label === "Cardio"
+                        ? "Requires VO2max from a Garmin watch model that exposes it (Forerunner / Fenix / Venu) — log a recent run on a compatible device."
+                        : undefined
+                    }
+                  >
+                    {label}
+                  </span>
                   <span
                     className={cn(
                       "font-mono text-xs",
                       getLongevityScoreColor(value),
                     )}
                   >
-                    {value == null ? "—" : value.toFixed(0)}
+                    {value == null ? (
+                      <span className="italic text-muted-foreground">
+                        no data
+                      </span>
+                    ) : (
+                      value.toFixed(0)
+                    )}
                   </span>
                 </div>
               ))}
@@ -205,9 +220,13 @@ export function LongevitySection({ longevityInsights }: LongevitySectionProps) {
                 <div className="flex justify-between text-sm mb-1">
                   <span className="text-muted-foreground">Zone 2 (7d)</span>
                   <span className="font-mono">
-                    {training_zones.zone2_minutes_7d == null
-                      ? "—"
-                      : `${String(Math.round(training_zones.zone2_minutes_7d))} min`}
+                    {training_zones.zone2_minutes_7d == null ? (
+                      <span className="text-xs text-muted-foreground italic">
+                        no zone-2 cardio this week
+                      </span>
+                    ) : (
+                      `${String(Math.round(training_zones.zone2_minutes_7d))} min`
+                    )}
                   </span>
                 </div>
                 <div className="flex justify-between text-sm">
@@ -242,9 +261,13 @@ export function LongevitySection({ longevityInsights }: LongevitySectionProps) {
                 <div className="flex justify-between text-sm mb-1">
                   <span className="text-muted-foreground">Zone 5 (7d)</span>
                   <span className="font-mono">
-                    {training_zones.zone5_minutes_7d == null
-                      ? "—"
-                      : `${String(Math.round(training_zones.zone5_minutes_7d))} min`}
+                    {training_zones.zone5_minutes_7d == null ? (
+                      <span className="text-xs text-muted-foreground italic">
+                        no zone-5 cardio this week
+                      </span>
+                    ) : (
+                      `${String(Math.round(training_zones.zone5_minutes_7d))} min`
+                    )}
                   </span>
                 </div>
                 <div className="flex justify-between text-sm">

--- a/src/analytics/sleep_index.py
+++ b/src/analytics/sleep_index.py
@@ -1,0 +1,164 @@
+"""Local Sleep Index — open-source approximation of a Sleep Fitness Score.
+
+Eight Sleep's official Sleep Fitness Score (sfs) is now read directly from
+`app-api.8slp.net/v1/users/<id>/metrics/summary`, but the underlying weights
+are an undisclosed adaptive engine and the field can disappear (subscription
+lapse, API revocation, host migration). This module computes a transparent,
+self-contained 0-100 score so we can keep showing a useful number even when
+the upstream value is null.
+
+Formula weights (rounded; sum to 1.0):
+    0.25  routine_score          (Eight Sleep wake-time consistency, when present)
+    0.20  quality_score          (Eight Sleep HR/HRV/RR/TnT composite, when present)
+    0.20  duration_score         (piecewise: 100 inside [7h, 9h], linear falloff)
+    0.10  efficiency_score       (AASM: sleep_min / time_in_bed_min)
+    0.08  deep_pct_score         (gaussian around 18% of TST)
+    0.07  rem_pct_score          (gaussian around 22% of TST)
+    0.05  latency_score          (100 inside [5, 20] min, penalty outside)
+    0.05  hrv_recovery_score     (z-score of overnight HRV vs trailing 28d mean)
+
+When `routine_score` or `quality_score` is null (e.g. Garmin/Whoop-only night),
+their weight is redistributed proportionally across the remaining components so
+the final score stays on the same 0-100 scale and remains source-agnostic.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SleepIndexInputs:
+    routine_score: int | None  # 0-100, Eight Sleep srs
+    quality_score: int | None  # 0-100, Eight Sleep sqs
+    total_sleep_minutes: float | None
+    time_in_bed_minutes: float | None
+    deep_minutes: float | None
+    rem_minutes: float | None
+    latency_asleep_minutes: float | None
+    hrv_overnight_ms: float | None
+    hrv_baseline_mean_ms: float | None  # trailing 28d mean
+    hrv_baseline_std_ms: float | None  # trailing 28d std
+
+
+_WEIGHTS = {
+    "routine": 0.25,
+    "quality": 0.20,
+    "duration": 0.20,
+    "efficiency": 0.10,
+    "deep_pct": 0.08,
+    "rem_pct": 0.07,
+    "latency": 0.05,
+    "hrv_recovery": 0.05,
+}
+
+
+def _duration_score(total_min: float | None) -> float | None:
+    if total_min is None or total_min <= 0:
+        return None
+    # Plateau between 7h and 9h, linear falloff to 0 at 4h or 11h.
+    if 420 <= total_min <= 540:
+        return 100.0
+    if total_min < 420:
+        return max(0.0, 100.0 * (total_min - 240) / (420 - 240))
+    return max(0.0, 100.0 * (660 - total_min) / (660 - 540))
+
+
+def _efficiency_score(
+    total_min: float | None, in_bed_min: float | None
+) -> float | None:
+    if total_min is None or in_bed_min is None or in_bed_min <= 0:
+        return None
+    eff = total_min / in_bed_min
+    if eff >= 0.95:
+        return 100.0
+    if eff <= 0.50:
+        return 0.0
+    return max(0.0, min(100.0, (eff - 0.50) / (0.95 - 0.50) * 100.0))
+
+
+def _gaussian_pct_score(
+    pct: float | None, target_pct: float, sigma: float
+) -> float | None:
+    if pct is None:
+        return None
+    deviation = (pct - target_pct) / sigma
+    return max(0.0, min(100.0, 100.0 * math.exp(-0.5 * deviation * deviation)))
+
+
+def _latency_score(latency_min: float | None) -> float | None:
+    if latency_min is None or latency_min < 0:
+        return None
+    if 5 <= latency_min <= 20:
+        return 100.0
+    if latency_min < 5:
+        return max(0.0, 100.0 * latency_min / 5.0)
+    if latency_min <= 60:
+        return max(0.0, 100.0 * (60 - latency_min) / (60 - 20))
+    return 0.0
+
+
+def _hrv_recovery_score(
+    overnight_ms: float | None,
+    baseline_mean_ms: float | None,
+    baseline_std_ms: float | None,
+) -> float | None:
+    if (
+        overnight_ms is None
+        or baseline_mean_ms is None
+        or baseline_std_ms is None
+        or baseline_std_ms <= 0
+    ):
+        return None
+    z = (overnight_ms - baseline_mean_ms) / baseline_std_ms
+    # Map z-score to 0-100; z=0 -> 50, z=+1 -> ~84, z=-1 -> ~16.
+    cdf = 0.5 * (1 + math.erf(z / math.sqrt(2)))
+    return max(0.0, min(100.0, cdf * 100.0))
+
+
+def compute_sleep_index(inputs: SleepIndexInputs) -> float | None:
+    """Return a 0-100 Sleep Index; None if no contributing component is available."""
+    deep_pct = (
+        100.0 * inputs.deep_minutes / inputs.total_sleep_minutes
+        if inputs.deep_minutes is not None
+        and inputs.total_sleep_minutes is not None
+        and inputs.total_sleep_minutes > 0
+        else None
+    )
+    rem_pct = (
+        100.0 * inputs.rem_minutes / inputs.total_sleep_minutes
+        if inputs.rem_minutes is not None
+        and inputs.total_sleep_minutes is not None
+        and inputs.total_sleep_minutes > 0
+        else None
+    )
+
+    components: dict[str, float | None] = {
+        "routine": (
+            float(inputs.routine_score) if inputs.routine_score is not None else None
+        ),
+        "quality": (
+            float(inputs.quality_score) if inputs.quality_score is not None else None
+        ),
+        "duration": _duration_score(inputs.total_sleep_minutes),
+        "efficiency": _efficiency_score(
+            inputs.total_sleep_minutes, inputs.time_in_bed_minutes
+        ),
+        "deep_pct": _gaussian_pct_score(deep_pct, target_pct=18.0, sigma=6.0),
+        "rem_pct": _gaussian_pct_score(rem_pct, target_pct=22.0, sigma=5.0),
+        "latency": _latency_score(inputs.latency_asleep_minutes),
+        "hrv_recovery": _hrv_recovery_score(
+            inputs.hrv_overnight_ms,
+            inputs.hrv_baseline_mean_ms,
+            inputs.hrv_baseline_std_ms,
+        ),
+    }
+
+    available_weight = sum(_WEIGHTS[k] for k, v in components.items() if v is not None)
+    if available_weight <= 0:
+        return None
+
+    weighted_sum = sum(_WEIGHTS[k] * v for k, v in components.items() if v is not None)
+    # Renormalise so missing components don't drag the score toward zero.
+    return max(0.0, min(100.0, weighted_sum / available_weight))

--- a/src/pull_eight_sleep_data.py
+++ b/src/pull_eight_sleep_data.py
@@ -5,7 +5,7 @@ import requests
 from sqlalchemy import select
 
 from database import get_db_session_context
-from date_utils import utcnow
+from date_utils import parse_iso_date, utcnow
 from eight_sleep_schemas import EightSleepSessionData
 from enums import DataSource, DataType
 from errors import CredentialsDecryptionError, CredentialsNotFoundError
@@ -23,6 +23,11 @@ logger = get_logger(__name__)
 
 AUTH_URL = "https://auth-api.8slp.net/v1/tokens"
 API_BASE_URL = "https://client-api.8slp.net/v1"
+# Sleep Fitness / Quality / Routine scores live on a different host than /trends.
+# Verified live 2026-04-29: GET app-api.8slp.net/v1/users/{id}/metrics/summary?metrics=all
+# returns {"days": [{"date": "...", "metrics": [{"name": "sfs", "value": "93"}, ...]}]}.
+# Also confirmed by mikeg0/eightctl audit (2026-03-15).
+METRICS_BASE_URL = "https://app-api.8slp.net/v1"
 CLIENT_ID = "0894c7f33bb94800a03f1f4df13a4f38"
 CLIENT_SECRET = "f0954a3ed5763ba3d06834c73731a32f15f168f47d4f164751275def86db0c76"  # pragma: allowlist secret
 REQUEST_TIMEOUT = 30
@@ -218,6 +223,70 @@ class EightSleepAPIClient:
         logger.info("eight_sleep_fetch_complete", total_nights=len(all_trends))
         return all_trends
 
+    def get_metrics_summary(
+        self,
+        start_date: datetime.date,
+        end_date: datetime.date,
+    ) -> dict[str, dict[str, str]]:
+        """Fetch daily Sleep Fitness / Quality / Routine scores from app-api.
+
+        Eight Sleep's /trends endpoint on client-api does NOT carry sleepFitnessScore.
+        The mobile app reads it from app-api.8slp.net/v1/users/<id>/metrics/summary,
+        which returns {"days": [{"date": "YYYY-MM-DD", "metrics": [
+            {"name": "sfs",   "value": "93"},
+            {"name": "sqs",   "value": "90"},
+            {"name": "srs",   "value": "96"},
+            ... ]}]}.
+
+        Returns: {date_iso: {metric_name: str_value}} keyed by ISO date.
+        Empty dict on auth/permission failure (logged, non-fatal — caller falls
+        back to whatever /trends provided).
+        """
+        eight_sleep_user_id = self._get_user_id()
+        try:
+            response = self._request_with_reauth(
+                "GET",
+                f"{METRICS_BASE_URL}/users/{eight_sleep_user_id}/metrics/summary",
+                params={
+                    "from": start_date.isoformat(),
+                    "to": end_date.isoformat(),
+                    "metrics": "all",
+                    "tz": "UTC",
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.exceptions.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else None
+            logger.warning(
+                "eight_sleep_metrics_summary_failed",
+                status=status,
+                detail=(exc.response.text[:200] if exc.response is not None else None),
+            )
+            return {}
+
+        data = response.json()
+        days = data.get("days") if isinstance(data, dict) else None
+        if not isinstance(days, list):
+            return {}
+
+        out: dict[str, dict[str, str]] = {}
+        for day in days:
+            if not isinstance(day, dict):
+                continue
+            date_iso = day.get("date")
+            metrics_list = day.get("metrics")
+            if not date_iso or not isinstance(metrics_list, list):
+                continue
+            metrics_map = {}
+            for entry in metrics_list:
+                if isinstance(entry, dict) and "name" in entry and "value" in entry:
+                    metrics_map[str(entry["name"])] = str(entry["value"])
+            if metrics_map:
+                out[date_iso] = metrics_map
+
+        logger.info("eight_sleep_metrics_summary_fetched", days=len(out))
+        return out
+
     def close(self) -> None:
         self._session.close()
 
@@ -277,6 +346,73 @@ def _write_eight_sleep_normalized(
         logger.info("eight_sleep_normalized_write_complete", user_id=user_id)
 
 
+def _safe_int_score(value: str | None) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _apply_metrics_summary_to_sessions(
+    user_id: int, metrics_by_date: dict[str, dict[str, str]]
+) -> None:
+    """Backfill sleep_fitness_score / sleep_routine_score / sleep_quality_score
+    on existing eight_sleep_sessions rows from the metrics/summary endpoint.
+
+    metrics_by_date keys are ISO date strings; values are {"sfs": "93", ...}.
+    Only writes when the row exists (so trends sync remains the source of truth
+    for non-score columns) and only when the new value is non-null.
+    """
+    from sqlalchemy import select
+
+    from models import EightSleepSession
+
+    if not metrics_by_date:
+        return
+
+    updated = 0
+    with get_db_session_context() as db:
+        for date_iso, metrics in metrics_by_date.items():
+            try:
+                session_date = parse_iso_date(date_iso)
+            except (ValueError, TypeError):
+                continue
+
+            sfs = _safe_int_score(metrics.get("sfs"))
+            sqs = _safe_int_score(metrics.get("sqs"))
+            srs = _safe_int_score(metrics.get("srs"))
+            sds = _safe_int_score(metrics.get("sds"))
+            if sfs is None and sqs is None and srs is None and sds is None:
+                continue
+
+            row = db.scalars(
+                select(EightSleepSession).where(
+                    EightSleepSession.user_id == user_id,
+                    EightSleepSession.date == session_date,
+                )
+            ).first()
+            if row is None:
+                continue
+
+            if sfs is not None:
+                row.sleep_fitness_score = sfs
+            if sqs is not None:
+                row.sleep_quality_score = sqs
+            if srs is not None:
+                row.sleep_routine_score = srs
+            if sds is not None and (row.score is None or row.score == 0):
+                # `sds` is "Sleep Duration Score" — keep the existing top-level
+                # `score` (overall) untouched if already populated by /trends.
+                pass
+            updated += 1
+
+    logger.info(
+        "eight_sleep_metrics_summary_applied", user_id=user_id, sessions_updated=updated
+    )
+
+
 def sync_eight_sleep_data_for_user(
     user_id: int, days: int = 90, full_sync: bool = False
 ) -> dict:
@@ -323,6 +459,23 @@ def sync_eight_sleep_data_for_user(
             source=DataSource.EIGHT_SLEEP,
             data_type=DataType.SLEEP,
         )
+
+        # Backfill the score columns from the metrics/summary endpoint, which
+        # is the only place sfs/sqs/srs are exposed (see METRICS_BASE_URL note).
+        # Non-fatal: if the endpoint fails or returns empty, the trends sync
+        # above still landed everything else.
+        if sync_result.success:
+            try:
+                metrics_by_date = api_client.get_metrics_summary(
+                    start_date=date_range.start_date,
+                    end_date=date_range.end_date,
+                )
+                if metrics_by_date:
+                    _apply_metrics_summary_to_sessions(user_id, metrics_by_date)
+            except Exception:
+                logger.exception(
+                    "eight_sleep_metrics_summary_apply_failed", user_id=user_id
+                )
 
         summary = {
             "user_id": user_id,

--- a/tests/test_sleep_index.py
+++ b/tests/test_sleep_index.py
@@ -1,0 +1,158 @@
+"""Integration tests for the local Sleep Index formula."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from analytics.sleep_index import SleepIndexInputs, compute_sleep_index
+
+
+def _good_night() -> SleepIndexInputs:
+    """A textbook excellent night: 8h total, 18% deep, 22% REM, 10min latency,
+    HRV right at baseline. Eight Sleep also said the night was 90/95."""
+    return SleepIndexInputs(
+        routine_score=95,
+        quality_score=90,
+        total_sleep_minutes=480,  # 8h
+        time_in_bed_minutes=505,  # eff ~95%
+        deep_minutes=86.4,  # 18% of 480
+        rem_minutes=105.6,  # 22% of 480
+        latency_asleep_minutes=10,
+        hrv_overnight_ms=55,
+        hrv_baseline_mean_ms=55,
+        hrv_baseline_std_ms=8,
+    )
+
+
+class TestSleepIndex:
+    def test_excellent_night_scores_high(self):
+        score = compute_sleep_index(_good_night())
+        assert score is not None
+        assert score >= 90
+
+    def test_short_sleep_drags_down(self):
+        bad = SleepIndexInputs(
+            **{**_good_night().__dict__, "total_sleep_minutes": 240},
+        )
+        bad = SleepIndexInputs(
+            routine_score=95,
+            quality_score=90,
+            total_sleep_minutes=240,  # 4h
+            time_in_bed_minutes=270,
+            deep_minutes=43,
+            rem_minutes=53,
+            latency_asleep_minutes=10,
+            hrv_overnight_ms=55,
+            hrv_baseline_mean_ms=55,
+            hrv_baseline_std_ms=8,
+        )
+        score = compute_sleep_index(bad)
+        good_score = compute_sleep_index(_good_night())
+        assert score is not None
+        assert good_score is not None
+        assert score < good_score
+        assert score < 80
+
+    def test_latency_penalty(self):
+        long_latency = SleepIndexInputs(
+            routine_score=95,
+            quality_score=90,
+            total_sleep_minutes=480,
+            time_in_bed_minutes=600,  # +60min lying awake = lower efficiency
+            deep_minutes=86,
+            rem_minutes=106,
+            latency_asleep_minutes=60,
+            hrv_overnight_ms=55,
+            hrv_baseline_mean_ms=55,
+            hrv_baseline_std_ms=8,
+        )
+        score = compute_sleep_index(long_latency)
+        good_score = compute_sleep_index(_good_night())
+        assert score is not None and good_score is not None
+        assert score < good_score
+
+    def test_hrv_above_baseline_helps(self):
+        high_hrv = SleepIndexInputs(
+            **{**_good_night().__dict__, "hrv_overnight_ms": 75},  # +2.5σ
+        )
+        score = compute_sleep_index(high_hrv)
+        baseline = compute_sleep_index(_good_night())
+        assert score is not None and baseline is not None
+        assert score >= baseline
+
+    def test_garmin_only_night_no_routine_no_quality(self):
+        """When Eight Sleep is offline (no routine/quality), formula still produces
+        a sensible score from duration + efficiency + architecture + latency + hrv."""
+        garmin_only = SleepIndexInputs(
+            routine_score=None,
+            quality_score=None,
+            total_sleep_minutes=470,
+            time_in_bed_minutes=500,
+            deep_minutes=82,
+            rem_minutes=104,
+            latency_asleep_minutes=12,
+            hrv_overnight_ms=55,
+            hrv_baseline_mean_ms=55,
+            hrv_baseline_std_ms=8,
+        )
+        score = compute_sleep_index(garmin_only)
+        assert score is not None
+        assert 70 <= score <= 100
+
+    def test_zero_data_returns_none(self):
+        empty = SleepIndexInputs(
+            routine_score=None,
+            quality_score=None,
+            total_sleep_minutes=None,
+            time_in_bed_minutes=None,
+            deep_minutes=None,
+            rem_minutes=None,
+            latency_asleep_minutes=None,
+            hrv_overnight_ms=None,
+            hrv_baseline_mean_ms=None,
+            hrv_baseline_std_ms=None,
+        )
+        assert compute_sleep_index(empty) is None
+
+    def test_score_is_clamped_to_0_100(self):
+        score = compute_sleep_index(_good_night())
+        assert score is not None
+        assert 0.0 <= score <= 100.0
+
+    def test_partial_data_redistributes_weights(self):
+        """Routine null but quality+duration+architecture present → still ~0-100."""
+        no_routine = SleepIndexInputs(
+            routine_score=None,
+            quality_score=85,
+            total_sleep_minutes=460,
+            time_in_bed_minutes=490,
+            deep_minutes=82,
+            rem_minutes=100,
+            latency_asleep_minutes=15,
+            hrv_overnight_ms=52,
+            hrv_baseline_mean_ms=55,
+            hrv_baseline_std_ms=8,
+        )
+        score = compute_sleep_index(no_routine)
+        assert score is not None
+        assert 0.0 <= score <= 100.0
+
+    @pytest.mark.parametrize(
+        "minutes, expected_min, expected_max",
+        [
+            (480, 95, 100),  # 8h plateau
+            (430, 95, 100),  # 7h12 plateau (in [420, 540])
+            (300, 0, 50),  # 5h significantly short
+            (200, 0, 0),  # under floor
+            (700, 0, 0),  # way over ceiling
+        ],
+    )
+    def test_duration_bands(self, minutes, expected_min, expected_max):
+        from analytics.sleep_index import _duration_score
+
+        score = _duration_score(minutes)
+        assert score is not None
+        assert expected_min <= score <= expected_max


### PR DESCRIPTION
## Summary

Closes the four "—" / null-value classes surfaced by QA on prod:

- **Eight Sleep Sleep Fitness Score** — restored. `client-api/v1/.../trends` no longer carries `sleepFitnessScore`; the live API field lives on a different host. New `EightSleepAPIClient.get_metrics_summary` hits `app-api.8slp.net/v1/users/<id>/metrics/summary?metrics=all` and backfills `sfs / sqs / srs` onto existing `eight_sleep_sessions` rows after `/trends` sync. Probed live 2026-04-29 against prod creds — endpoint returns `sfs=93` for today.
- **VO2max / longevity Cardio score** — DIAGNOSIS only. Verified via `psql`: 0/768 `garmin_training_status` rows have a non-null `vo2_max` for `user_id=1` (`fitness_age` is populated, so the fetch path works). Genuine "watch model does not expose VO2max" case. UI now surfaces this with a tooltip instead of bare em-dash.
- **Zone 2/5 (7d) nulls** — last cardio activity was 2026-04-03 (26 days stale). Genuine "no recent cardio". UI now reads "no zone-2 cardio this week" instead of "—".
- **Local Sleep Index** — transparent 0-100 fallback formula `0.25*routine + 0.20*quality + 0.20*duration + 0.10*efficiency + 0.08*deep% + 0.07*REM% + 0.05*latency + 0.05*HRV_recovery`, with weight redistribution when ES inputs are null. 13 integration tests cover excellent/short/latency/HRV/Garmin-only/empty/clamping cases. Not yet wired into sync — kept as a library function for the next iteration.

## Diagnostic SQL (Step A — paste-only artefact)

```
SELECT date, vo2_max, vo2_max_precise, fitness_age FROM garmin_training_status WHERE user_id=1 ORDER BY date DESC LIMIT 30;
-- 30 rows, all (date, NULL, NULL, 33)
SELECT COUNT(*) FROM garmin_training_status WHERE user_id=1 AND vo2_max IS NOT NULL;
-- 0
SELECT COUNT(*) FROM garmin_training_status WHERE user_id=1;
-- 768

SELECT date, activity_type, hr_zone_two_seconds, hr_zone_five_seconds FROM garmin_activities WHERE user_id=1 ORDER BY date DESC LIMIT 5;
-- (2026-04-03, 'running', 160, 0) -- 26d stale
-- (2026-03-25, 'indoor_cycling', 146, 0)
-- ...
```

## Test plan

- [x] Backend: 77/77 pytest pass (added 13 in `tests/test_sleep_index.py`)
- [x] Live probe of new Eight Sleep endpoint from prod pod returned 200 + `sfs` value
- [x] Frontend `tsc --noEmit` clean
- [ ] Post-deploy: trigger Eight Sleep sync, confirm `sleep_fitness_score` populates non-null on recent rows
- [ ] Post-deploy: confirm `/dashboard/sleep` Sleep Fitness card shows the score
- [ ] Post-deploy: confirm `/dashboard/statistics` Zone 7d / Cardio cells show explanatory copy

## Commits

1. `53e3ac9` — Eight Sleep app-api integration (Step D)
2. `94c4821` — cause-aware copy on Zone 7d / Cardio cells (Step B)
3. `fbddc7d` — local Sleep Index formula + tests (Step C)