### PR TITLE
Bot: accept photos and forward them to the chat agent

### DIFF
--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -206,7 +206,12 @@ class HealthAgent:
         ]
         return self._run_tool_loop(user_id, messages, SYSTEM_PROMPT)
 
-    def chat(self, user_id: int, message: str, conversation: Conversation) -> str:
+    def chat(
+        self,
+        user_id: int,
+        message: str | list[dict[str, Any]],
+        conversation: Conversation,
+    ) -> str:
         if conversation.needs_context_refresh():
             context_summary = build_chat_context(user_id)
             conversation.add_user_message(f"[Health context update]\n{context_summary}")

--- a/src/agent/bot_message_repo.py
+++ b/src/agent/bot_message_repo.py
@@ -31,6 +31,8 @@ def _flatten_dict_block(block: dict[str, Any]) -> str | None:
     if block_type == "text":
         text = block.get("text")
         return text or None
+    if block_type == "image":
+        return "[image]"
     if block_type == "tool_use":
         return f"[tool_use:{block.get('name', '?')}]"
     if block_type == "tool_result":
@@ -120,9 +122,30 @@ def _is_replayable(role: str, content: Any) -> bool:
         return True
     if isinstance(content, list):
         if role == "user":
-            return False
+            return all(
+                isinstance(b, dict) and b.get("type") in ("text", "image")
+                for b in content
+            )
         return all(isinstance(b, dict) and b.get("type") == "text" for b in content)
     return False
+
+
+def _strip_image_blocks(content: Any) -> Any:
+    """Replace image blocks with text placeholders when reloading history.
+
+    Keeps token usage bounded across bot restarts — the visual data only
+    matters for the turn it arrived in; afterwards a marker is enough to
+    keep the conversation coherent.
+    """
+    if not isinstance(content, list):
+        return content
+    sanitized: list[Any] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "image":
+            sanitized.append({"type": "text", "text": "[прикреплённое фото]"})
+        else:
+            sanitized.append(block)
+    return sanitized
 
 
 def load_recent_messages(
@@ -143,7 +166,7 @@ def load_recent_messages(
         )
     rows = list(reversed(rows))
     replayable = [
-        {"role": role, "content": content}
+        {"role": role, "content": _strip_image_blocks(content)}
         for role, content in rows
         if _is_replayable(role, content)
     ]

--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -26,16 +26,16 @@ class Conversation:
 
     def add_user_message(
         self,
-        text: str,
+        content: Any,
         *,
         source: str = "chat",
         telegram_message_id: int | None = None,
     ) -> None:
-        self.messages.append({"role": "user", "content": text})
+        self.messages.append({"role": "user", "content": content})
         self._trim()
         self._persist(
             "user",
-            text,
+            content,
             source=source,
             telegram_message_id=telegram_message_id,
         )

--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -18,6 +18,7 @@ from bot.commands import (
     cmd_status,
     cmd_week,
     handle_message,
+    handle_photo,
 )
 from bot.config import BotConfig
 from bot.scheduler import schedule_push_notifications
@@ -60,6 +61,12 @@ def create_bot(config: BotConfig | None = None) -> Application:
         MessageHandler(
             filters.TEXT & ~filters.COMMAND,
             auth_required(handle_message),
+        )
+    )
+    app.add_handler(
+        MessageHandler(
+            filters.PHOTO,
+            auth_required(handle_photo),
         )
     )
 

--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -1,3 +1,4 @@
+import base64
 from datetime import date
 
 from telegram import Update
@@ -208,3 +209,46 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     except Exception:
         logger.exception("handle_message_failed")
         await update.message.reply_text("Ошибка при обработке вопроса. Попробуй позже.")
+
+
+async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    config: BotConfig = context.bot_data["config"]
+    store: ConversationStore = context.bot_data["conversations"]
+    chat_id = update.effective_chat.id
+
+    if not update.message.photo:
+        return
+
+    await update.message.reply_chat_action("typing")
+    try:
+        photo = update.message.photo[-1]
+        tg_file = await context.bot.get_file(photo.file_id)
+        buf = await tg_file.download_as_bytearray()
+        encoded = base64.standard_b64encode(bytes(buf)).decode("ascii")
+        caption = (update.message.caption or "").strip()
+
+        content: list[dict] = [
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/jpeg",
+                    "data": encoded,
+                },
+            },
+            {
+                "type": "text",
+                "text": caption
+                or "Что на фото? Если это связано со здоровьем — прокомментируй.",
+            },
+        ]
+
+        agent = _get_agent()
+        conversation = store.get(chat_id, user_id=config.db_user_id)
+        answer = agent.chat(config.db_user_id, content, conversation)
+        await send_markdown_safe(
+            update.message.reply_text, truncate_for_telegram(answer)
+        )
+    except Exception:
+        logger.exception("handle_photo_failed")
+        await update.message.reply_text("Ошибка при обработке фото. Попробуй позже.")


### PR DESCRIPTION
Adds a Telegram PHOTO handler that downloads the largest photo, base64-
encodes it, and passes an image+text content block list to the existing
HealthAgent.chat() flow. The conversation store now persists user content
as JSON blocks; reloaded image blocks are replaced with a "[прикреплённое
фото]" placeholder so token usage stays bounded across bot restarts.

https://claude.ai/code/session_01Uw4uwpx5EuzujG9RWfgMib